### PR TITLE
Update user model fields

### DIFF
--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -10,30 +10,15 @@ mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true })
   .catch(err => console.error('Error al conectar con MongoDB:', err));
 
 const userSchema = new mongoose.Schema({
-  id: Number,
   username: String,
   password: String,
-  nombre: String,
-  numeroTelefono: String,
-  tipoUsuario: String
+  name: String,
+  phoneNum: String,
+  userType: String
 });
 
 const User = mongoose.model('User', userSchema);
 
-// Crear usuario inicial si la colección está vacía
-mongoose.connection.once('open', async () => {
-  const count = await User.countDocuments();
-  if (count === 0) {
-    await User.create({
-      id: 1,
-      username: 'admin',
-      password: 'admin',
-      nombre: 'Administrador',
-      numeroTelefono: '0000',
-      tipoUsuario: 'super'
-    });
-  }
-});
 
 const app = express();
 app.use(cors());            // permite peticiones desde tu frontend
@@ -47,7 +32,7 @@ app.post('/api/login', async (req, res) => {
   try {
     const user = await User.findOne({ username, password });
     if (!user) return res.status(401).json({ message: 'Credenciales inválidas' });
-    res.json({ user: { id: user.id, nombre: user.nombre, numeroTelefono: user.numeroTelefono, tipoUsuario: user.tipoUsuario } });
+    res.json({ user: { _id: user._id, name: user.name, phoneNum: user.phoneNum, userType: user.userType } });
   } catch (err) {
     res.status(500).json({ message: 'Error al consultar usuario' });
   }
@@ -61,8 +46,7 @@ app.get('/api/users', async (req, res) => {
 
 app.post('/api/users', async (req, res) => {
   try {
-    const count = await User.countDocuments();
-    const newUser = await User.create({ id: count + 1, ...req.body });
+    const newUser = await User.create(req.body);
     res.status(201).json(newUser);
   } catch (err) {
     res.status(500).json({ message: 'Error al crear usuario' });

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -8,7 +8,7 @@ import {
 
 export default function UsuariosPage() {
   const [users, setUsers] = useState([]);
-  const [newUser, setNewUser] = useState({ id: '', nombre: '', numeroTelefono: '', tipoUsuario: '' });
+  const [newUser, setNewUser] = useState({ username: '', password: '', name: '', phoneNum: '', userType: '' });
 
   useEffect(() => {
     fetchUsers().then(res => setUsers(res.data));
@@ -18,7 +18,7 @@ export default function UsuariosPage() {
     await createUser(newUser);
     const { data } = await fetchUsers();
     setUsers(data);
-    setNewUser({ id: '', nombre: '', numeroTelefono: '', tipoUsuario: '' });
+    setNewUser({ username: '', password: '', name: '', phoneNum: '', userType: '' });
   };
 
   return (
@@ -29,27 +29,29 @@ export default function UsuariosPage() {
           <TableHead>
             <TableRow>
               <TableCell>ID</TableCell>
+              <TableCell>Usuario</TableCell>
               <TableCell>Nombre</TableCell>
               <TableCell>Teléfono</TableCell>
               <TableCell>Tipo</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {users.map(u => (
-              <TableRow key={u.id}>
-                <TableCell>{u.id}</TableCell>
-                <TableCell>{u.nombre}</TableCell>
-                <TableCell>{u.numeroTelefono}</TableCell>
-                <TableCell>{u.tipoUsuario}</TableCell>
-              </TableRow>
-            ))}
+              {users.map(u => (
+                <TableRow key={u._id}>
+                  <TableCell>{u._id}</TableCell>
+                  <TableCell>{u.username}</TableCell>
+                  <TableCell>{u.name}</TableCell>
+                  <TableCell>{u.phoneNum}</TableCell>
+                  <TableCell>{u.userType}</TableCell>
+                </TableRow>
+              ))}
           </TableBody>
         </Table>
       </Paper>
       <Box sx={{ mt: 4 }}>
         <Typography variant="h6">Agregar Usuario</Typography>
         <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
-          {['id','nombre','numeroTelefono','tipoUsuario'].map(field => (
+          {['username','password','name','phoneNum','userType'].map(field => (
             <TextField
               key={field}
               label={field.charAt(0).toUpperCase() + field.slice(1)}


### PR DESCRIPTION
## Summary
- revise user schema to use `_id`, username, password, name, phoneNum and userType
- remove automatic creation of the admin user
- update login and user creation API
- adjust front‑end user management page to use new field names

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844d6dcdf7c83308e157986cc706eb3