### PR TITLE
Prevent duplicate users and display password column

### DIFF
--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -46,6 +46,15 @@ app.get('/api/users', async (req, res) => {
 
 app.post('/api/users', async (req, res) => {
   try {
+    const { username, phoneNum } = req.body;
+    const existing = await User.findOne({
+      $or: [{ username }, { phoneNum }]
+    });
+    if (existing) {
+      return res
+        .status(400)
+        .json({ message: 'Usuario o teléfono ya existe' });
+    }
     const newUser = await User.create(req.body);
     res.status(201).json(newUser);
   } catch (err) {

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -24,11 +24,12 @@ export default function UsuariosPage() {
   return (
     <Container>
       <Typography variant="h4" gutterBottom>Usuarios</Typography>
-      <Paper>
-        <Table>
+      <Paper sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table sx={{ minWidth: 800 }}>
           <TableHead>
             <TableRow>
               <TableCell>Usuario</TableCell>
+              <TableCell>Password</TableCell>
               <TableCell>Nombre</TableCell>
               <TableCell>Teléfono</TableCell>
               <TableCell>Tipo</TableCell>
@@ -38,6 +39,7 @@ export default function UsuariosPage() {
               {users.map(u => (
                 <TableRow key={u._id}>
                   <TableCell>{u.username}</TableCell>
+                  <TableCell>{u.password}</TableCell>
                   <TableCell>{u.name}</TableCell>
                   <TableCell>{u.phoneNum}</TableCell>
                   <TableCell>{u.userType}</TableCell>


### PR DESCRIPTION
## Summary
- ensure backend rejects duplicate username or phone number
- show password column on Users table and make it a bit wider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844dbba2b308330b8c8dc7dc5848ed5