### PR TITLE
Implement user type selector and duplicate warnings

### DIFF
--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -3,22 +3,30 @@ import React, { useEffect, useState } from 'react';
 import { fetchUsers, createUser } from '../services/users';
 import {
   Container, Typography, TextField, Button, Box,
-  Paper, Table, TableHead, TableRow, TableCell, TableBody
+  Paper, Table, TableHead, TableRow, TableCell, TableBody,
+  Alert, FormControl, InputLabel, Select, MenuItem
 } from '@mui/material';
 
 export default function UsuariosPage() {
   const [users, setUsers] = useState([]);
   const [newUser, setNewUser] = useState({ username: '', password: '', name: '', phoneNum: '', userType: '' });
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetchUsers().then(res => setUsers(res.data));
   }, []);
 
   const handleAdd = async () => {
-    await createUser(newUser);
-    const { data } = await fetchUsers();
-    setUsers(data);
-    setNewUser({ username: '', password: '', name: '', phoneNum: '', userType: '' });
+    try {
+      await createUser(newUser);
+      const { data } = await fetchUsers();
+      setUsers(data);
+      setNewUser({ username: '', password: '', name: '', phoneNum: '', userType: '' });
+      setError('');
+    } catch (err) {
+      const msg = err.response?.data?.message || 'Error al crear usuario';
+      setError(msg);
+    }
   };
 
   return (
@@ -50,8 +58,9 @@ export default function UsuariosPage() {
       </Paper>
       <Box sx={{ mt: 4 }}>
         <Typography variant="h6">Agregar Usuario</Typography>
+        {error && <Alert severity="warning" sx={{ width: '100%', mb: 2 }}>{error}</Alert>}
         <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
-          {['username','password','name','phoneNum','userType'].map(field => (
+          {['username', 'password', 'name', 'phoneNum'].map(field => (
             <TextField
               key={field}
               label={field.charAt(0).toUpperCase() + field.slice(1)}
@@ -59,6 +68,19 @@ export default function UsuariosPage() {
               onChange={e => setNewUser(n => ({ ...n, [field]: e.target.value }))}
             />
           ))}
+          <FormControl sx={{ minWidth: 120 }}>
+            <InputLabel id="user-type-label">Tipo</InputLabel>
+            <Select
+              labelId="user-type-label"
+              value={newUser.userType}
+              label="Tipo"
+              onChange={e => setNewUser(n => ({ ...n, userType: e.target.value }))}
+            >
+              {['admin', 'cliente', 'custom'].map(opt => (
+                <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
           <Button variant="contained" onClick={handleAdd}>Agregar</Button>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- replace `userType` text field with a select box
- show a warning alert when the API reports duplicate username or phone number

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844ddf03f588330acce6b571617288f