### PR TITLE
Add user delete option

### DIFF
--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -62,4 +62,13 @@ app.post('/api/users', async (req, res) => {
   }
 });
 
+app.delete('/api/users/:id', async (req, res) => {
+  try {
+    await User.findByIdAndDelete(req.params.id);
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ message: 'Error al eliminar usuario' });
+  }
+});
+
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -1,16 +1,19 @@
 // src/pages/UsuariosPage.jsx
 import React, { useEffect, useState } from 'react';
-import { fetchUsers, createUser } from '../services/users';
+import { fetchUsers, createUser, deleteUser } from '../services/users';
 import {
   Container, Typography, TextField, Button, Box,
   Paper, Table, TableHead, TableRow, TableCell, TableBody,
-  Alert, FormControl, InputLabel, Select, MenuItem
+  Alert, FormControl, InputLabel, Select, MenuItem,
+  IconButton, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions
 } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 export default function UsuariosPage() {
   const [users, setUsers] = useState([]);
   const [newUser, setNewUser] = useState({ username: '', password: '', name: '', phoneNum: '', userType: '' });
   const [error, setError] = useState('');
+  const [deleteId, setDeleteId] = useState(null);
 
   useEffect(() => {
     fetchUsers().then(res => setUsers(res.data));
@@ -29,6 +32,18 @@ export default function UsuariosPage() {
     }
   };
 
+  const handleDelete = async () => {
+    try {
+      await deleteUser(deleteId);
+      const { data } = await fetchUsers();
+      setUsers(data);
+    } catch (err) {
+      setError('Error al eliminar usuario');
+    } finally {
+      setDeleteId(null);
+    }
+  };
+
   return (
     <Container>
       <Typography variant="h4" gutterBottom>Usuarios</Typography>
@@ -41,6 +56,7 @@ export default function UsuariosPage() {
               <TableCell>Nombre</TableCell>
               <TableCell>Teléfono</TableCell>
               <TableCell>Tipo</TableCell>
+              <TableCell>Acciones</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -51,6 +67,11 @@ export default function UsuariosPage() {
                   <TableCell>{u.name}</TableCell>
                   <TableCell>{u.phoneNum}</TableCell>
                   <TableCell>{u.userType}</TableCell>
+                  <TableCell>
+                    <IconButton color="error" onClick={() => setDeleteId(u._id)}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </TableCell>
                 </TableRow>
               ))}
           </TableBody>
@@ -84,6 +105,18 @@ export default function UsuariosPage() {
           <Button variant="contained" onClick={handleAdd}>Agregar</Button>
         </Box>
       </Box>
+      <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
+        <DialogTitle>Confirmar eliminación</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            ¿Desea eliminar este usuario?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteId(null)}>Cancelar</Button>
+          <Button color="error" onClick={handleDelete}>Eliminar</Button>
+        </DialogActions>
+      </Dialog>
     </Container>
   );
 }

--- a/webapp bot bms/frontend/src/services/users.js
+++ b/webapp bot bms/frontend/src/services/users.js
@@ -2,3 +2,4 @@ import axios from 'axios';
 
 export const fetchUsers = () => axios.get('/api/users');
 export const createUser = (user) => axios.post('/api/users', user);
+export const deleteUser = (id) => axios.delete(`/api/users/${id}`);


### PR DESCRIPTION
## Summary
- implement `DELETE /api/users/:id` in backend
- expose deleteUser service
- add delete button and confirmation dialog on user table

## Testing
- `node --check webapp bot bms/backend/index.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844e029cc408330ab118a96682966c7