### PR TITLE
Add Group CRUD page and group selection for users

### DIFF
--- a/webapp bot bms/backend/controllers/groupController.js
+++ b/webapp bot bms/backend/controllers/groupController.js
@@ -1,0 +1,28 @@
+import Group from '../models/Group.js';
+
+export const getGroups = async (req, res) => {
+  try {
+    const groups = await Group.find();
+    res.json(groups);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al obtener grupos' });
+  }
+};
+
+export const createGroup = async (req, res) => {
+  try {
+    const newGroup = await Group.create(req.body);
+    res.status(201).json(newGroup);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al crear grupo' });
+  }
+};
+
+export const deleteGroup = async (req, res) => {
+  try {
+    await Group.findByIdAndDelete(req.params.id);
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ message: 'Error al eliminar grupo' });
+  }
+};

--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -4,6 +4,7 @@ import bodyParser from 'body-parser';
 import './config/database.js';
 import userRoutes from './routes/userRoutes.js';
 import clientRoutes from './routes/clientRoutes.js';
+import groupRoutes from './routes/groupRoutes.js';
 
 const app = express();
 app.use(cors());
@@ -11,5 +12,6 @@ app.use(bodyParser.json());
 
 app.use('/api', userRoutes);
 app.use('/api', clientRoutes);
+app.use('/api', groupRoutes);
 
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/backend/routes/groupRoutes.js
+++ b/webapp bot bms/backend/routes/groupRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getGroups, createGroup, deleteGroup } from '../controllers/groupController.js';
+
+const router = express.Router();
+
+router.get('/groups', getGroups);
+router.post('/groups', createGroup);
+router.delete('/groups/:id', deleteGroup);
+
+export default router;

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import UsuariosPage from './pages/UsuariosPage';
 import PuntosPage from './pages/PuntosPage';
+import GroupPage from './pages/GroupPage';
 import Layout from './components/Layout'; 
 import { useAuth } from './context/AuthContext';
 
@@ -22,6 +23,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <UsuariosPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/grupos"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <GroupPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Drawer, List, ListItemButton, ListItemIcon, ListItemText, Toolbar } from '@mui/material';
 import PeopleIcon from '@mui/icons-material/People';
 import StarIcon from '@mui/icons-material/Star';
+import GroupsIcon from '@mui/icons-material/Groups';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -20,6 +21,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/usuarios" activeClassName="Mui-selected" exact>
           <ListItemIcon><PeopleIcon /></ListItemIcon>
           <ListItemText primary="Usuarios" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/grupos" activeClassName="Mui-selected" exact>
+          <ListItemIcon><GroupsIcon /></ListItemIcon>
+          <ListItemText primary="Grupos" />
         </ListItemButton>
         <ListItemButton component={NavLink} to="/puntos" activeClassName="Mui-selected" exact>
           <ListItemIcon><StarIcon /></ListItemIcon>

--- a/webapp bot bms/frontend/src/pages/GroupPage.jsx
+++ b/webapp bot bms/frontend/src/pages/GroupPage.jsx
@@ -1,0 +1,102 @@
+// src/pages/GroupPage.jsx
+import React, { useEffect, useState } from 'react';
+import { fetchGroups, createGroup, deleteGroup } from '../services/groups';
+import {
+  Container, Typography, TextField, Button, Box,
+  Paper, Table, TableHead, TableRow, TableCell, TableBody,
+  IconButton, Dialog, DialogTitle, DialogContent, DialogContentText,
+  DialogActions, Alert
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+export default function GroupPage() {
+  const [groups, setGroups] = useState([]);
+  const [newGroup, setNewGroup] = useState({ groupName: '', description: '' });
+  const [error, setError] = useState('');
+  const [deleteId, setDeleteId] = useState(null);
+
+  useEffect(() => {
+    fetchGroups().then(res => setGroups(res.data));
+  }, []);
+
+  const handleAdd = async () => {
+    try {
+      await createGroup(newGroup);
+      const { data } = await fetchGroups();
+      setGroups(data);
+      setNewGroup({ groupName: '', description: '' });
+      setError('');
+    } catch (err) {
+      setError('Error al crear grupo');
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteGroup(deleteId);
+      const { data } = await fetchGroups();
+      setGroups(data);
+    } catch (err) {
+      setError('Error al eliminar grupo');
+    } finally {
+      setDeleteId(null);
+    }
+  };
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Grupos</Typography>
+      <Paper sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table sx={{ minWidth: 600 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Nombre</TableCell>
+              <TableCell>Descripción</TableCell>
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groups.map(g => (
+              <TableRow key={g._id}>
+                <TableCell>{g.groupName}</TableCell>
+                <TableCell>{g.description}</TableCell>
+                <TableCell>
+                  <IconButton color="error" onClick={() => setDeleteId(g._id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+      <Box sx={{ mt: 4 }}>
+        <Typography variant="h6">Agregar Grupo</Typography>
+        {error && <Alert severity="warning" sx={{ width: '100%', mb: 2 }}>{error}</Alert>}
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+          <TextField
+            label="Nombre"
+            value={newGroup.groupName}
+            onChange={e => setNewGroup(n => ({ ...n, groupName: e.target.value }))}
+          />
+          <TextField
+            label="Descripción"
+            value={newGroup.description}
+            onChange={e => setNewGroup(n => ({ ...n, description: e.target.value }))}
+          />
+          <Button variant="contained" onClick={handleAdd}>Agregar</Button>
+        </Box>
+      </Box>
+      <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
+        <DialogTitle>Confirmar eliminación</DialogTitle>
+        <DialogContent>
+          <DialogContentText>¿Desea eliminar este grupo?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteId(null)}>Cancelar</Button>
+          <Button color="error" onClick={handleDelete}>Eliminar</Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+}

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -1,6 +1,7 @@
 // src/pages/UsuariosPage.jsx
 import React, { useEffect, useState } from 'react';
 import { fetchUsers, createUser, deleteUser } from '../services/users';
+import { fetchGroups } from '../services/groups';
 import {
   Container, Typography, TextField, Button, Box,
   Paper, Table, TableHead, TableRow, TableCell, TableBody,
@@ -11,12 +12,14 @@ import DeleteIcon from '@mui/icons-material/Delete';
 
 export default function UsuariosPage() {
   const [users, setUsers] = useState([]);
-  const [newUser, setNewUser] = useState({ username: '', password: '', name: '', phoneNum: '', userType: '' });
+  const [newUser, setNewUser] = useState({ username: '', password: '', name: '', phoneNum: '', userType: '', groupId: '' });
+  const [groups, setGroups] = useState([]);
   const [error, setError] = useState('');
   const [deleteId, setDeleteId] = useState(null);
 
   useEffect(() => {
     fetchUsers().then(res => setUsers(res.data));
+    fetchGroups().then(res => setGroups(res.data));
   }, []);
 
   const handleAdd = async () => {
@@ -24,7 +27,7 @@ export default function UsuariosPage() {
       await createUser(newUser);
       const { data } = await fetchUsers();
       setUsers(data);
-      setNewUser({ username: '', password: '', name: '', phoneNum: '', userType: '' });
+      setNewUser({ username: '', password: '', name: '', phoneNum: '', userType: '', groupId: '' });
       setError('');
     } catch (err) {
       const msg = err.response?.data?.message || 'Error al crear usuario';
@@ -99,6 +102,19 @@ export default function UsuariosPage() {
             >
               {['admin', 'cliente', 'custom'].map(opt => (
                 <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl sx={{ minWidth: 120 }}>
+            <InputLabel id="group-label">Grupo</InputLabel>
+            <Select
+              labelId="group-label"
+              value={newUser.groupId}
+              label="Grupo"
+              onChange={e => setNewUser(n => ({ ...n, groupId: e.target.value }))}
+            >
+              {groups.map(g => (
+                <MenuItem key={g._id} value={g._id}>{g.groupName}</MenuItem>
               ))}
             </Select>
           </FormControl>

--- a/webapp bot bms/frontend/src/services/groups.js
+++ b/webapp bot bms/frontend/src/services/groups.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const fetchGroups = () => axios.get('/api/groups');
+export const createGroup = (group) => axios.post('/api/groups', group);
+export const deleteGroup = (id) => axios.delete(`/api/groups/${id}`);


### PR DESCRIPTION
## Summary
- implement backend routes and controller for groups
- register `groupRoutes` in express app
- add frontend service and GroupPage for CRUD operations
- show group dropdown in Users page when creating users
- add route and sidebar entry for GroupPage

## Testing
- `npm test --silent` *(fails: "Error: no test specified")*
- `npm --version`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6858ee15053c8330883ec956ebb86fbc