### PR TITLE
Add client CRUD page and update models

### DIFF
--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -1,4 +1,9 @@
 import Client from '../models/Client.js';
+import crypto from 'crypto';
+
+function generateApiKey() {
+  return crypto.randomBytes(32).toString('hex');
+}
 
 export const getClients = async (req, res) => {
   try {
@@ -11,7 +16,12 @@ export const getClients = async (req, res) => {
 
 export const createClient = async (req, res) => {
   try {
-    const newClient = await Client.create(req.body);
+    const data = {
+      ...req.body,
+      apiKey: generateApiKey(),
+      ipAddress: '',
+    };
+    const newClient = await Client.create(data);
     res.status(201).json(newClient);
   } catch (err) {
     res.status(500).json({ message: 'Error al crear cliente' });

--- a/webapp bot bms/backend/models/Client.js
+++ b/webapp bot bms/backend/models/Client.js
@@ -2,11 +2,12 @@ import mongoose from '../config/database.js';
 
 const clientSchema = new mongoose.Schema({
   clientName: String,
-  asiKey: String,
+  apiKey: String,
   enabled: String,
   ipAddress: String,
   location: String,
-  groupIp: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' }
+  groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
+  connectionStatus: { type: Boolean, default: false }
 });
 
 export default mongoose.model('Client', clientSchema);

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage';
 import UsuariosPage from './pages/UsuariosPage';
 import PuntosPage from './pages/PuntosPage';
 import GroupPage from './pages/GroupPage';
+import ClientPage from './pages/ClientPage';
 import Layout from './components/Layout'; 
 import { useAuth } from './context/AuthContext';
 
@@ -33,6 +34,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <GroupPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/clientes"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <ClientPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -3,6 +3,7 @@ import { Drawer, List, ListItemButton, ListItemIcon, ListItemText, Toolbar } fro
 import PeopleIcon from '@mui/icons-material/People';
 import StarIcon from '@mui/icons-material/Star';
 import GroupsIcon from '@mui/icons-material/Groups';
+import DevicesIcon from '@mui/icons-material/Devices';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -25,6 +26,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/grupos" activeClassName="Mui-selected" exact>
           <ListItemIcon><GroupsIcon /></ListItemIcon>
           <ListItemText primary="Grupos" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/clientes" activeClassName="Mui-selected" exact>
+          <ListItemIcon><DevicesIcon /></ListItemIcon>
+          <ListItemText primary="Clientes" />
         </ListItemButton>
         <ListItemButton component={NavLink} to="/puntos" activeClassName="Mui-selected" exact>
           <ListItemIcon><StarIcon /></ListItemIcon>

--- a/webapp bot bms/frontend/src/pages/ClientPage.jsx
+++ b/webapp bot bms/frontend/src/pages/ClientPage.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { fetchClients, createClient, deleteClient } from '../services/clients';
+import { fetchGroups } from '../services/groups';
+import {
+  Container, Typography, TextField, Button, Box,
+  Paper, Table, TableHead, TableRow, TableCell, TableBody,
+  IconButton, Dialog, DialogTitle, DialogContent, DialogContentText,
+  DialogActions, FormControl, InputLabel, Select, MenuItem, Alert
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+export default function ClientPage() {
+  const [clients, setClients] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [newClient, setNewClient] = useState({ clientName: '', location: '', groupId: '' });
+  const [error, setError] = useState('');
+  const [deleteId, setDeleteId] = useState(null);
+
+  useEffect(() => {
+    fetchClients().then(res => setClients(res.data));
+    fetchGroups().then(res => setGroups(res.data));
+  }, []);
+
+  const handleAdd = async () => {
+    try {
+      await createClient(newClient);
+      const { data } = await fetchClients();
+      setClients(data);
+      setNewClient({ clientName: '', location: '', groupId: '' });
+      setError('');
+    } catch (err) {
+      setError('Error al crear cliente');
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteClient(deleteId);
+      const { data } = await fetchClients();
+      setClients(data);
+    } catch (err) {
+      setError('Error al eliminar cliente');
+    } finally {
+      setDeleteId(null);
+    }
+  };
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Clientes</Typography>
+      <Paper sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table sx={{ minWidth: 800 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Nombre</TableCell>
+              <TableCell>ApiKey</TableCell>
+              <TableCell>Enabled</TableCell>
+              <TableCell>IP</TableCell>
+              <TableCell>Ubicación</TableCell>
+              <TableCell>Grupo</TableCell>
+              <TableCell>Conectado</TableCell>
+              <TableCell>Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {clients.map(c => (
+              <TableRow key={c._id}>
+                <TableCell>{c.clientName}</TableCell>
+                <TableCell>{c.apiKey}</TableCell>
+                <TableCell>{c.enabled}</TableCell>
+                <TableCell>{c.ipAddress}</TableCell>
+                <TableCell>{c.location}</TableCell>
+                <TableCell>{c.groupId}</TableCell>
+                <TableCell>{String(c.connectionStatus)}</TableCell>
+                <TableCell>
+                  <IconButton color="error" onClick={() => setDeleteId(c._id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+      <Box sx={{ mt: 4 }}>
+        <Typography variant="h6">Agregar Cliente</Typography>
+        {error && <Alert severity="warning" sx={{ width: '100%', mb: 2 }}>{error}</Alert>}
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+          <TextField
+            label="Nombre"
+            value={newClient.clientName}
+            onChange={e => setNewClient(n => ({ ...n, clientName: e.target.value }))}
+          />
+          <TextField
+            label="Ubicación"
+            value={newClient.location}
+            onChange={e => setNewClient(n => ({ ...n, location: e.target.value }))}
+          />
+          <FormControl sx={{ minWidth: 120 }}>
+            <InputLabel id="group-label">Grupo</InputLabel>
+            <Select
+              labelId="group-label"
+              value={newClient.groupId}
+              label="Grupo"
+              onChange={e => setNewClient(n => ({ ...n, groupId: e.target.value }))}
+            >
+              {groups.map(g => (
+                <MenuItem key={g._id} value={g._id}>{g.groupName}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Button variant="contained" onClick={handleAdd}>Agregar</Button>
+        </Box>
+      </Box>
+      <Dialog open={Boolean(deleteId)} onClose={() => setDeleteId(null)}>
+        <DialogTitle>Confirmar eliminación</DialogTitle>
+        <DialogContent>
+          <DialogContentText>¿Desea eliminar este cliente?</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteId(null)}>Cancelar</Button>
+          <Button color="error" onClick={handleDelete}>Eliminar</Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+}

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -59,6 +59,7 @@ export default function UsuariosPage() {
               <TableCell>Nombre</TableCell>
               <TableCell>Teléfono</TableCell>
               <TableCell>Tipo</TableCell>
+              <TableCell>Grupo</TableCell>
               <TableCell>Acciones</TableCell>
             </TableRow>
           </TableHead>
@@ -70,6 +71,7 @@ export default function UsuariosPage() {
                   <TableCell>{u.name}</TableCell>
                   <TableCell>{u.phoneNum}</TableCell>
                   <TableCell>{u.userType}</TableCell>
+                  <TableCell>{u.groupId}</TableCell>
                   <TableCell>
                     <IconButton color="error" onClick={() => setDeleteId(u._id)}>
                       <DeleteIcon />

--- a/webapp bot bms/frontend/src/services/clients.js
+++ b/webapp bot bms/frontend/src/services/clients.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const fetchClients = () => axios.get('/api/clients');
+export const createClient = (client) => axios.post('/api/clients', client);
+export const deleteClient = (id) => axios.delete(`/api/clients/${id}`);


### PR DESCRIPTION
## Summary
- extend `Client` model with `apiKey`, `groupId` and `connectionStatus`
- auto-generate `apiKey` using crypto when creating a client
- add new `ClientPage` with CRUD operations
- expose client API helpers
- show user group in `UsuariosPage`
- add Clients link to sidebar and route to router

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858f447d88083308cabb1f4bd7fffe2