### PR TITLE
Improve table display and show group names

### DIFF
--- a/webapp bot bms/frontend/src/pages/ClientPage.jsx
+++ b/webapp bot bms/frontend/src/pages/ClientPage.jsx
@@ -49,7 +49,7 @@ export default function ClientPage() {
     <Container>
       <Typography variant="h4" gutterBottom>Clientes</Typography>
       <Paper sx={{ width: '100%', overflowX: 'auto' }}>
-        <Table sx={{ minWidth: 800 }}>
+        <Table sx={{ minWidth: 1200 }}>
           <TableHead>
             <TableRow>
               <TableCell>Nombre</TableCell>
@@ -70,7 +70,7 @@ export default function ClientPage() {
                 <TableCell>{c.enabled}</TableCell>
                 <TableCell>{c.ipAddress}</TableCell>
                 <TableCell>{c.location}</TableCell>
-                <TableCell>{c.groupId}</TableCell>
+                <TableCell>{groups.find(g => g._id === c.groupId)?.groupName || c.groupId}</TableCell>
                 <TableCell>{String(c.connectionStatus)}</TableCell>
                 <TableCell>
                   <IconButton color="error" onClick={() => setDeleteId(c._id)}>

--- a/webapp bot bms/frontend/src/pages/GroupPage.jsx
+++ b/webapp bot bms/frontend/src/pages/GroupPage.jsx
@@ -47,7 +47,7 @@ export default function GroupPage() {
     <Container>
       <Typography variant="h4" gutterBottom>Grupos</Typography>
       <Paper sx={{ width: '100%', overflowX: 'auto' }}>
-        <Table sx={{ minWidth: 600 }}>
+        <Table sx={{ minWidth: 800 }}>
           <TableHead>
             <TableRow>
               <TableCell>Nombre</TableCell>

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -51,7 +51,7 @@ export default function UsuariosPage() {
     <Container>
       <Typography variant="h4" gutterBottom>Usuarios</Typography>
       <Paper sx={{ width: '100%', overflowX: 'auto' }}>
-        <Table sx={{ minWidth: 800 }}>
+        <Table sx={{ minWidth: 1200 }}>
           <TableHead>
             <TableRow>
               <TableCell>Usuario</TableCell>
@@ -71,7 +71,7 @@ export default function UsuariosPage() {
                   <TableCell>{u.name}</TableCell>
                   <TableCell>{u.phoneNum}</TableCell>
                   <TableCell>{u.userType}</TableCell>
-                  <TableCell>{u.groupId}</TableCell>
+                  <TableCell>{groups.find(g => g._id === u.groupId)?.groupName || u.groupId}</TableCell>
                   <TableCell>
                     <IconButton color="error" onClick={() => setDeleteId(u._id)}>
                       <DeleteIcon />


### PR DESCRIPTION
## Summary
- widen tables across pages
- show group names instead of IDs for users and clients

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858f91a8b18833083de59507114acd0