### PR TITLE
Update clients page

### DIFF
--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -36,3 +36,17 @@ export const deleteClient = async (req, res) => {
     res.status(500).json({ message: 'Error al eliminar cliente' });
   }
 };
+
+export const updateClientEnabled = async (req, res) => {
+  try {
+    const { enabled } = req.body;
+    const client = await Client.findByIdAndUpdate(
+      req.params.id,
+      { enabled },
+      { new: true }
+    );
+    res.json(client);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al actualizar cliente' });
+  }
+};

--- a/webapp bot bms/backend/routes/clientRoutes.js
+++ b/webapp bot bms/backend/routes/clientRoutes.js
@@ -1,10 +1,11 @@
 import express from 'express';
-import { getClients, createClient, deleteClient } from '../controllers/clientController.js';
+import { getClients, createClient, deleteClient, updateClientEnabled } from '../controllers/clientController.js';
 
 const router = express.Router();
 
 router.get('/clients', getClients);
 router.post('/clients', createClient);
 router.delete('/clients/:id', deleteClient);
+router.patch('/clients/:id/enabled', updateClientEnabled);
 
 export default router;

--- a/webapp bot bms/frontend/src/services/clients.js
+++ b/webapp bot bms/frontend/src/services/clients.js
@@ -3,3 +3,5 @@ import axios from 'axios';
 export const fetchClients = () => axios.get('/api/clients');
 export const createClient = (client) => axios.post('/api/clients', client);
 export const deleteClient = (id) => axios.delete(`/api/clients/${id}`);
+export const updateClientEnabled = (id, enabled) =>
+  axios.patch(`/api/clients/${id}/enabled`, { enabled });


### PR DESCRIPTION
## Summary
- add endpoint to toggle client enabled state
- allow frontend to toggle enabled and hide/show ApiKey
- add status icons for connection and enabled columns

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858fc60b17c8330b23f0cf554399e2e