### PR TITLE
Update client enabled flag

### DIFF
--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -42,7 +42,7 @@ export const updateClientEnabled = async (req, res) => {
     const { enabled } = req.body;
     const client = await Client.findByIdAndUpdate(
       req.params.id,
-      { enabled },
+      { enabled: Boolean(enabled) },
       { new: true }
     );
     res.json(client);

--- a/webapp bot bms/backend/models/Client.js
+++ b/webapp bot bms/backend/models/Client.js
@@ -3,7 +3,7 @@ import mongoose from '../config/database.js';
 const clientSchema = new mongoose.Schema({
   clientName: String,
   apiKey: String,
-  enabled: String,
+  enabled: { type: Boolean, default: false },
   ipAddress: String,
   location: String,
   groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },


### PR DESCRIPTION
## Summary
- change Client.enabled schema field to boolean with default `false`
- ensure toggling enabled state on backend parses boolean

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859070c6eb88330b6e9b09578884d79