### PR TITLE
Change top bar color

### DIFF
--- a/webapp bot bms/frontend/src/components/TopBar.jsx
+++ b/webapp bot bms/frontend/src/components/TopBar.jsx
@@ -20,7 +20,13 @@ export default function TopBar() {
   };
 
   return (
-    <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+    <AppBar
+      position="fixed"
+      sx={{
+        zIndex: (theme) => theme.zIndex.drawer + 1,
+        backgroundColor: '#424242',
+      }}
+    >
       <Toolbar>
         <Typography variant="h6" component="div" sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
           FusionBMS


### PR DESCRIPTION
## Summary
- use a dark gray background for the top navigation bar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68591698450883309dd5ef1ccdf129da