### PR TITLE
Add point state reporting API

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -1,0 +1,34 @@
+import Client from '../models/Client.js';
+import Point from '../models/Point.js';
+import DataLog from '../models/DataLog.js';
+
+export const reportState = async (req, res) => {
+  try {
+    const { apiKey, pointName, ipAddress, pointType, pointId, presentValue } = req.body;
+    if (!apiKey) {
+      return res.status(400).json({ message: 'apiKey requerido' });
+    }
+
+    const client = await Client.findOne({ apiKey });
+    if (!client) {
+      return res.status(401).json({ message: 'apiKey inválido' });
+    }
+
+    let point = await Point.findOne({ pointName, clientId: client._id });
+    if (!point) {
+      point = await Point.create({
+        pointName,
+        ipAddress,
+        pointType,
+        pointId,
+        clientId: client._id
+      });
+    }
+
+    await DataLog.create({ pointId: point._id, presentValue });
+    res.status(201).json({ message: 'Estado registrado' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al procesar datos' });
+  }
+};

--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -5,6 +5,7 @@ import './config/database.js';
 import userRoutes from './routes/userRoutes.js';
 import clientRoutes from './routes/clientRoutes.js';
 import groupRoutes from './routes/groupRoutes.js';
+import pointRoutes from './routes/pointRoutes.js';
 
 const app = express();
 app.use(cors());
@@ -13,5 +14,6 @@ app.use(bodyParser.json());
 app.use('/api', userRoutes);
 app.use('/api', clientRoutes);
 app.use('/api', groupRoutes);
+app.use('/api', pointRoutes);
 
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/backend/models/DataLog.js
+++ b/webapp bot bms/backend/models/DataLog.js
@@ -1,0 +1,9 @@
+import mongoose from '../config/database.js';
+
+const dataLogSchema = new mongoose.Schema({
+  pointId: { type: mongoose.Schema.Types.ObjectId, ref: 'Point' },
+  presentValue: mongoose.Schema.Types.Mixed,
+  timestamp: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('DataLog', dataLogSchema);

--- a/webapp bot bms/backend/routes/pointRoutes.js
+++ b/webapp bot bms/backend/routes/pointRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { reportState } from '../controllers/pointController.js';
+
+const router = express.Router();
+
+router.post('/points/state', reportState);
+
+export default router;


### PR DESCRIPTION
## Summary
- add DataLog model for point value logs
- add controller and route to report point states
- hook new route into backend API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874dd9dd8488330a23463a05b3ecec9