### PR TITLE
Implement Points listing

### DIFF
--- a/webapp bot bms/backend/routes/pointRoutes.js
+++ b/webapp bot bms/backend/routes/pointRoutes.js
@@ -1,8 +1,9 @@
 import express from 'express';
-import { reportState } from '../controllers/pointController.js';
+import { reportState, getPoints } from '../controllers/pointController.js';
 
 const router = express.Router();
 
 router.post('/points/state', reportState);
+router.get('/points', getPoints);
 
 export default router;

--- a/webapp bot bms/frontend/src/pages/PuntosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/PuntosPage.jsx
@@ -1,13 +1,118 @@
-import React from 'react';
-import { Container, Typography, Box } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import {
+  Container,
+  Typography,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Box,
+} from '@mui/material';
+import { fetchPoints } from '../services/points';
+import { fetchClients } from '../services/clients';
+import { fetchGroups } from '../services/groups';
 
 export default function PuntosPage() {
+  const [points, setPoints] = useState([]);
+  const [clients, setClients] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [clientId, setClientId] = useState('');
+  const [groupId, setGroupId] = useState('');
+
+  const loadPoints = async (cId, gId) => {
+    const { data } = await fetchPoints(cId, gId);
+    setPoints(data);
+  };
+
+  useEffect(() => {
+    fetchClients().then((res) => setClients(res.data));
+    fetchGroups().then((res) => setGroups(res.data));
+    loadPoints('', '');
+  }, []);
+
+  useEffect(() => {
+    loadPoints(clientId, groupId);
+  }, [clientId, groupId]);
+
   return (
     <Container>
-      <Typography variant="h4" gutterBottom>Puntos (En Desarrollo)</Typography>
-      <Box>
-        <Typography>Esta página de Puntos aún no está implementada.</Typography>
+      <Typography variant="h4" gutterBottom>
+        Puntos
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <FormControl sx={{ minWidth: 160 }}>
+          <InputLabel id="client-label">Cliente</InputLabel>
+          <Select
+            labelId="client-label"
+            value={clientId}
+            label="Cliente"
+            onChange={(e) => setClientId(e.target.value)}
+          >
+            <MenuItem value="">Todos</MenuItem>
+            {clients.map((c) => (
+              <MenuItem key={c._id} value={c._id}>
+                {c.clientName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 160 }}>
+          <InputLabel id="group-label">Grupo</InputLabel>
+          <Select
+            labelId="group-label"
+            value={groupId}
+            label="Grupo"
+            onChange={(e) => setGroupId(e.target.value)}
+          >
+            <MenuItem value="">Todos</MenuItem>
+            {groups.map((g) => (
+              <MenuItem key={g._id} value={g._id}>
+                {g.groupName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Box>
+      <Paper sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table sx={{ minWidth: 1200 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Nombre</TableCell>
+              <TableCell>IP</TableCell>
+              <TableCell>Tipo</TableCell>
+              <TableCell>PointId</TableCell>
+              <TableCell>Cliente</TableCell>
+              <TableCell>Grupo</TableCell>
+              <TableCell>Last Value</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {points.map((p) => (
+              <TableRow key={p._id}>
+                <TableCell>{p.pointName}</TableCell>
+                <TableCell>{p.ipAddress}</TableCell>
+                <TableCell>{p.pointType}</TableCell>
+                <TableCell>{p.pointId}</TableCell>
+                <TableCell>{p.clientId?.clientName || p.clientId}</TableCell>
+                <TableCell>{p.groupId?.groupName || p.groupId}</TableCell>
+                <TableCell>
+                  {p.lastValue
+                    ? `${p.lastValue.presentValue} (${new Date(
+                        p.lastValue.timestamp
+                      ).toLocaleString()})`
+                    : 'N/A'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
     </Container>
   );
 }

--- a/webapp bot bms/frontend/src/services/points.js
+++ b/webapp bot bms/frontend/src/services/points.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const fetchPoints = (clientId, groupId) => {
+  const params = {};
+  if (clientId) params.clientId = clientId;
+  if (groupId) params.groupId = groupId;
+  return axios.get('/api/points', { params });
+};


### PR DESCRIPTION
## Summary
- fetch point data with related last values via new GET `/points`
- create a service helper for points
- add comboboxes to filter Points by client or group and show last present value
- expose `/api/points` endpoint in the backend

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix frontend run lint` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d43e3ec8330a6a73b00cbca5790