### PR TITLE
Fix Puntos page group column

### DIFF
--- a/webapp bot bms/frontend/src/pages/PuntosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/PuntosPage.jsx
@@ -100,7 +100,21 @@ export default function PuntosPage() {
                 <TableCell>{p.pointType}</TableCell>
                 <TableCell>{p.pointId}</TableCell>
                 <TableCell>{p.clientId?.clientName || p.clientId}</TableCell>
-                <TableCell>{p.groupId?.groupName || p.groupId}</TableCell>
+                <TableCell>
+                  {(() => {
+                    const cidGroup = p.clientId?.groupId;
+                    if (cidGroup && typeof cidGroup === 'object') {
+                      return cidGroup.groupName;
+                    }
+                    return (
+                      groups.find((g) => g._id === cidGroup)?.groupName ||
+                      p.groupId?.groupName ||
+                      cidGroup ||
+                      p.groupId ||
+                      'N/A'
+                    );
+                  })()}
+                </TableCell>
                 <TableCell>
                   {p.lastValue
                     ? `${p.lastValue.presentValue} (${new Date(


### PR DESCRIPTION
## Summary
- display group name in points table using client's groupId

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a31797848833092524bd732a43864