### PR TITLE
Add Twilio webhook to display incoming messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ El cuerpo de la petición debe tener la clave `apiKey` y un arreglo `points` con
 
 Cada objeto dentro de `points` describe un punto y su valor actual. El servidor validará la `apiKey`, registrará el punto si no existe y almacenará el valor recibido.
 
+
+## Configuración de Twilio
+
+Se añadió un endpoint para almacenar las credenciales de Twilio y enviar mensajes de WhatsApp.
+
+- `GET /api/twilio` devuelve la configuración actual.
+- `POST /api/twilio` guarda la configuración (`accountSid`, `authToken` y `whatsappFrom`).
+- `POST /api/twilio/send` envía un mensaje de prueba recibiendo `to` y `body`.
+- `POST /api/twilio/webhook` endpoint para el webhook de Twilio que recibe los mensajes entrantes.
+- `GET /api/twilio/messages` devuelve los mensajes recibidos más recientes.

--- a/webapp bot bms/backend/controllers/twilioController.js
+++ b/webapp bot bms/backend/controllers/twilioController.js
@@ -1,0 +1,82 @@
+import TwilioConfig from '../models/TwilioConfig.js';
+import TwilioMessage from '../models/TwilioMessage.js';
+
+export const getConfig = async (req, res) => {
+  const config = await TwilioConfig.findOne();
+  res.json(config || {});
+};
+
+export const updateConfig = async (req, res) => {
+  try {
+    const { accountSid, authToken, whatsappFrom } = req.body;
+    let config = await TwilioConfig.findOne();
+    if (config) {
+      config.accountSid = accountSid;
+      config.authToken = authToken;
+      config.whatsappFrom = whatsappFrom;
+      await config.save();
+    } else {
+      config = await TwilioConfig.create({ accountSid, authToken, whatsappFrom });
+    }
+    res.json(config);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al guardar configuración' });
+  }
+};
+
+export const sendMessage = async (req, res) => {
+  try {
+    const { to, body } = req.body;
+    const config = await TwilioConfig.findOne();
+    if (!config) return res.status(400).json({ message: 'Config no encontrada' });
+    const params = new URLSearchParams();
+    params.append('From', `whatsapp:${config.whatsappFrom}`);
+    params.append('To', `whatsapp:${to}`);
+    params.append('Body', body);
+
+    const url = `https://api.twilio.com/2010-04-01/Accounts/${config.accountSid}/Messages.json`;
+    const auth = Buffer.from(`${config.accountSid}:${config.authToken}`).toString('base64');
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text);
+    }
+
+    const data = await response.json();
+    res.json({ sid: data.sid });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al enviar mensaje' });
+  }
+};
+
+export const twilioWebhook = async (req, res) => {
+  try {
+    const { From, Body } = req.body;
+    if (From && Body) {
+      await TwilioMessage.create({ from: From, body: Body });
+    }
+    res.set('Content-Type', 'text/plain');
+    res.send('');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('');
+  }
+};
+
+export const getMessages = async (req, res) => {
+  try {
+    const msgs = await TwilioMessage.find().sort({ timestamp: -1 });
+    res.json(msgs);
+  } catch {
+    res.status(500).json({ message: 'Error al obtener mensajes' });
+  }
+};

--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -6,6 +6,7 @@ import userRoutes from './routes/userRoutes.js';
 import clientRoutes from './routes/clientRoutes.js';
 import groupRoutes from './routes/groupRoutes.js';
 import pointRoutes from './routes/pointRoutes.js';
+import twilioRoutes from './routes/twilioRoutes.js';
 
 const app = express();
 app.use(cors());
@@ -15,5 +16,6 @@ app.use('/api', userRoutes);
 app.use('/api', clientRoutes);
 app.use('/api', groupRoutes);
 app.use('/api', pointRoutes);
+app.use('/api', twilioRoutes);
 
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/backend/models/TwilioConfig.js
+++ b/webapp bot bms/backend/models/TwilioConfig.js
@@ -1,0 +1,9 @@
+import mongoose from '../config/database.js';
+
+const twilioConfigSchema = new mongoose.Schema({
+  accountSid: String,
+  authToken: String,
+  whatsappFrom: String
+});
+
+export default mongoose.model('TwilioConfig', twilioConfigSchema);

--- a/webapp bot bms/backend/models/TwilioMessage.js
+++ b/webapp bot bms/backend/models/TwilioMessage.js
@@ -1,0 +1,9 @@
+import mongoose from '../config/database.js';
+
+const twilioMessageSchema = new mongoose.Schema({
+  from: String,
+  body: String,
+  timestamp: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('TwilioMessage', twilioMessageSchema);

--- a/webapp bot bms/backend/routes/twilioRoutes.js
+++ b/webapp bot bms/backend/routes/twilioRoutes.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import {
+  getConfig,
+  updateConfig,
+  sendMessage,
+  twilioWebhook,
+  getMessages
+} from '../controllers/twilioController.js';
+const router = express.Router();
+
+router.get('/twilio', getConfig);
+router.post('/twilio', updateConfig);
+router.post('/twilio/send', sendMessage);
+router.post('/twilio/webhook', express.urlencoded({ extended: false }), twilioWebhook);
+router.get('/twilio/messages', getMessages);
+
+export default router;

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import UsuariosPage from './pages/UsuariosPage';
 import PuntosPage from './pages/PuntosPage';
 import GroupPage from './pages/GroupPage';
 import ClientPage from './pages/ClientPage';
+import TwilioPage from './pages/TwilioPage';
 import Layout from './components/Layout'; 
 import { useAuth } from './context/AuthContext';
 
@@ -54,6 +55,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <PuntosPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/twilio"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <TwilioPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import StarIcon from '@mui/icons-material/Star';
 import GroupsIcon from '@mui/icons-material/Groups';
 import DevicesIcon from '@mui/icons-material/Devices';
+import ChatIcon from '@mui/icons-material/Chat';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -34,6 +35,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/puntos" activeClassName="Mui-selected" exact>
           <ListItemIcon><StarIcon /></ListItemIcon>
           <ListItemText primary="Puntos" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/twilio" activeClassName="Mui-selected" exact>
+          <ListItemIcon><ChatIcon /></ListItemIcon>
+          <ListItemText primary="Twilio" />
         </ListItemButton>
       </List>
     </Drawer>

--- a/webapp bot bms/frontend/src/pages/TwilioPage.jsx
+++ b/webapp bot bms/frontend/src/pages/TwilioPage.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Typography, TextField, Button, Box, Alert } from '@mui/material';
+import { fetchConfig, saveConfig, sendTestMessage, fetchMessages } from '../services/twilio';
+
+export default function TwilioPage() {
+  const [config, setConfig] = useState({ accountSid: '', authToken: '', whatsappFrom: '' });
+  const [test, setTest] = useState({ to: '', body: '' });
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    fetchConfig().then(res => {
+      if (res.data) setConfig({
+        accountSid: res.data.accountSid || '',
+        authToken: res.data.authToken || '',
+        whatsappFrom: res.data.whatsappFrom || ''
+      });
+    });
+    loadMessages();
+  }, []);
+
+  const loadMessages = async () => {
+    try {
+      const res = await fetchMessages();
+      setMessages(res.data || []);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      await saveConfig(config);
+      setMessage('Configuración guardada');
+      setError('');
+    } catch {
+      setError('Error al guardar');
+      setMessage('');
+    }
+  };
+
+  const handleSend = async () => {
+    try {
+      await sendTestMessage(test);
+      setMessage('Mensaje enviado');
+      setError('');
+    } catch {
+      setError('Error al enviar mensaje');
+      setMessage('');
+    }
+  };
+
+  const handleRefresh = () => {
+    loadMessages();
+  };
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>Twilio API</Typography>
+      {message && <Alert severity="success" sx={{ mb:2 }}>{message}</Alert>}
+      {error && <Alert severity="warning" sx={{ mb:2 }}>{error}</Alert>}
+      <Box sx={{ display:'flex', flexDirection:'column', gap:2, maxWidth:400 }}>
+        <TextField label="Account SID" value={config.accountSid} onChange={e=>setConfig(c=>({...c, accountSid:e.target.value}))} />
+        <TextField label="Auth Token" value={config.authToken} onChange={e=>setConfig(c=>({...c, authToken:e.target.value}))} />
+        <TextField label="WhatsApp From" value={config.whatsappFrom} onChange={e=>setConfig(c=>({...c, whatsappFrom:e.target.value}))} />
+        <Button variant="contained" onClick={handleSave}>Guardar</Button>
+      </Box>
+      <Box sx={{ display:'flex', flexDirection:'column', gap:2, maxWidth:400, mt:4 }}>
+        <Typography variant="h6">Enviar mensaje de prueba</Typography>
+        <TextField label="Para" value={test.to} onChange={e=>setTest(t=>({...t, to:e.target.value}))} />
+        <TextField label="Mensaje" value={test.body} onChange={e=>setTest(t=>({...t, body:e.target.value}))} />
+        <Button variant="contained" onClick={handleSend}>Enviar</Button>
+      </Box>
+      <Box sx={{ mt:4 }}>
+        <Box sx={{ display:'flex', alignItems:'center', mb:1 }}>
+          <Typography variant="h6" sx={{ flexGrow:1 }}>Mensajes recibidos</Typography>
+          <Button size="small" variant="outlined" onClick={handleRefresh}>Refrescar</Button>
+        </Box>
+        <Box sx={{ maxHeight:300, overflowY:'auto', border:'1px solid #ccc', p:1 }}>
+          {messages.map(m => (
+            <Box key={m._id} sx={{ mb:1 }}>
+              <Typography variant="caption" color="text.secondary">{new Date(m.timestamp).toLocaleString()} - {m.from}</Typography>
+              <Typography>{m.body}</Typography>
+            </Box>
+          ))}
+          {messages.length === 0 && <Typography variant="body2">Sin mensajes</Typography>}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/webapp bot bms/frontend/src/services/twilio.js
+++ b/webapp bot bms/frontend/src/services/twilio.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const fetchConfig = () => axios.get('/api/twilio');
+export const saveConfig = (config) => axios.post('/api/twilio', config);
+export const sendTestMessage = (data) => axios.post('/api/twilio/send', data);
+export const fetchMessages = () => axios.get('/api/twilio/messages');


### PR DESCRIPTION
## Summary
- support storing incoming WhatsApp messages
- expose `/api/twilio/messages` and webhook endpoint
- show incoming messages in the Twilio page
- document new Twilio endpoints

## Testing
- `node -e "import('./webapp bot bms/backend/controllers/twilioController.js').then(()=>console.log('ok')).catch(err=>console.error(err));"`


------
https://chatgpt.com/codex/tasks/task_e_687a4544e5588330bdad76c05b1ac147