### PR TITLE
Add WhatsApp chat page with live messaging

### DIFF
--- a/webapp bot bms/backend/controllers/twilioController.js
+++ b/webapp bot bms/backend/controllers/twilioController.js
@@ -51,6 +51,14 @@ export const sendMessage = async (req, res) => {
     }
 
     const data = await response.json();
+
+    await TwilioMessage.create({
+      from: `whatsapp:${config.whatsappFrom}`,
+      to: `whatsapp:${to}`,
+      body,
+      direction: 'outbound'
+    });
+
     res.json({ sid: data.sid });
   } catch (err) {
     console.error(err);
@@ -60,9 +68,14 @@ export const sendMessage = async (req, res) => {
 
 export const twilioWebhook = async (req, res) => {
   try {
-    const { From, Body } = req.body;
+    const { From, To, Body } = req.body;
     if (From && Body) {
-      await TwilioMessage.create({ from: From, body: Body });
+      await TwilioMessage.create({
+        from: From,
+        to: To,
+        body: Body,
+        direction: 'inbound'
+      });
     }
     res.set('Content-Type', 'text/plain');
     res.send('');

--- a/webapp bot bms/backend/models/TwilioMessage.js
+++ b/webapp bot bms/backend/models/TwilioMessage.js
@@ -2,7 +2,9 @@ import mongoose from '../config/database.js';
 
 const twilioMessageSchema = new mongoose.Schema({
   from: String,
+  to: String,
   body: String,
+  direction: String,
   timestamp: { type: Date, default: Date.now }
 });
 

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import PuntosPage from './pages/PuntosPage';
 import GroupPage from './pages/GroupPage';
 import ClientPage from './pages/ClientPage';
 import TwilioPage from './pages/TwilioPage';
+import WhatsappPage from './pages/WhatsappPage';
 import Layout from './components/Layout'; 
 import { useAuth } from './context/AuthContext';
 
@@ -65,6 +66,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <TwilioPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/whatsapp"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <WhatsappPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -5,6 +5,7 @@ import StarIcon from '@mui/icons-material/Star';
 import GroupsIcon from '@mui/icons-material/Groups';
 import DevicesIcon from '@mui/icons-material/Devices';
 import ChatIcon from '@mui/icons-material/Chat';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -39,6 +40,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/twilio" activeClassName="Mui-selected" exact>
           <ListItemIcon><ChatIcon /></ListItemIcon>
           <ListItemText primary="Twilio" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/whatsapp" activeClassName="Mui-selected" exact>
+          <ListItemIcon><WhatsAppIcon /></ListItemIcon>
+          <ListItemText primary="WhatsApp" />
         </ListItemButton>
       </List>
     </Drawer>

--- a/webapp bot bms/frontend/src/pages/WhatsappPage.jsx
+++ b/webapp bot bms/frontend/src/pages/WhatsappPage.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Container,
+  Typography,
+  Box,
+  TextField,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem
+} from '@mui/material';
+import { fetchMessages, sendMessage } from '../services/twilio';
+import { fetchUsers } from '../services/users';
+
+export default function WhatsappPage() {
+  const [messages, setMessages] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [selected, setSelected] = useState('');
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, 5000);
+    fetchUsers().then(res => setUsers(res.data));
+    return () => clearInterval(interval);
+  }, []);
+
+  const load = async () => {
+    try {
+      const res = await fetchMessages();
+      setMessages(res.data.reverse());
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleSend = async () => {
+    if (!selected || !text) return;
+    await sendMessage({ to: selected, body: text });
+    setText('');
+    load();
+  };
+
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>WhatsApp</Typography>
+      <Box sx={{ border: '1px solid #ccc', p:1, mb:2, height: 400, overflowY:'auto', display:'flex', flexDirection:'column' }}>
+        {messages.map(m => (
+          <Box
+            key={m._id}
+            sx={{
+              alignSelf: m.direction === 'outbound' ? 'flex-end' : 'flex-start',
+              bgcolor: m.direction === 'outbound' ? 'primary.main' : 'grey.300',
+              color: m.direction === 'outbound' ? 'white' : 'black',
+              mb: 1,
+              p: 1,
+              borderRadius: 1,
+              maxWidth: '70%'
+            }}
+          >
+            <Typography variant="caption" sx={{ display:'block' }}>
+              {new Date(m.timestamp).toLocaleString()}
+            </Typography>
+            <Typography variant="body2">{m.body}</Typography>
+          </Box>
+        ))}
+      </Box>
+      <Box sx={{ display:'flex', gap:2 }}>
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel id="contact-label">Contacto</InputLabel>
+          <Select
+            labelId="contact-label"
+            value={selected}
+            label="Contacto"
+            onChange={e => setSelected(e.target.value)}
+          >
+            {users.map(u => (
+              <MenuItem key={u._id} value={u.phoneNum}>{u.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          fullWidth
+          label="Mensaje"
+          value={text}
+          onChange={e => setText(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleSend}>Enviar</Button>
+      </Box>
+    </Container>
+  );
+}

--- a/webapp bot bms/frontend/src/services/twilio.js
+++ b/webapp bot bms/frontend/src/services/twilio.js
@@ -3,4 +3,5 @@ import axios from 'axios';
 export const fetchConfig = () => axios.get('/api/twilio');
 export const saveConfig = (config) => axios.post('/api/twilio', config);
 export const sendTestMessage = (data) => axios.post('/api/twilio/send', data);
+export const sendMessage = (data) => axios.post('/api/twilio/send', data);
 export const fetchMessages = () => axios.get('/api/twilio/messages');


### PR DESCRIPTION
## Summary
- log outgoing WhatsApp messages in the backend
- store message `to` and `direction` fields
- create `WhatsappPage` for chatting
- expose WhatsApp page on sidebar and router
- add sendMessage helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d6c45a6dc83308d859f4c0275cfc6