### PR TITLE
Add alarm WhatsApp sender config

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -3,7 +3,7 @@ import Point from '../models/Point.js';
 import DataLog from '../models/DataLog.js';
 import Alarm from '../models/Alarm.js';
 import User from '../models/User.js';
-import { sendWhatsApp } from '../services/twilioService.js';
+import { sendAlarmWhatsApp } from '../services/twilioService.js';
 
 export const reportState = async (req, res) => {
   try {
@@ -50,7 +50,7 @@ export const reportState = async (req, res) => {
           for (const u of users) {
             if (u.phoneNum) {
               try {
-                await sendWhatsApp(u.phoneNum, `Alarma en ${point.pointName}: ${presentValue}`);
+                await sendAlarmWhatsApp(u.phoneNum, u.username, point.pointName);
               } catch (e) {
                 console.error('Error enviando WhatsApp', e.message);
               }

--- a/webapp bot bms/backend/controllers/twilioController.js
+++ b/webapp bot bms/backend/controllers/twilioController.js
@@ -8,15 +8,17 @@ export const getConfig = async (req, res) => {
 
 export const updateConfig = async (req, res) => {
   try {
-    const { accountSid, authToken, whatsappFrom } = req.body;
+    const { accountSid, authToken, whatsappFrom, messagingServiceSid, contentSid } = req.body;
     let config = await TwilioConfig.findOne();
     if (config) {
       config.accountSid = accountSid;
       config.authToken = authToken;
       config.whatsappFrom = whatsappFrom;
+      config.messagingServiceSid = messagingServiceSid;
+      config.contentSid = contentSid;
       await config.save();
     } else {
-      config = await TwilioConfig.create({ accountSid, authToken, whatsappFrom });
+      config = await TwilioConfig.create({ accountSid, authToken, whatsappFrom, messagingServiceSid, contentSid });
     }
     res.json(config);
   } catch (err) {

--- a/webapp bot bms/backend/models/TwilioConfig.js
+++ b/webapp bot bms/backend/models/TwilioConfig.js
@@ -3,7 +3,9 @@ import mongoose from '../config/database.js';
 const twilioConfigSchema = new mongoose.Schema({
   accountSid: String,
   authToken: String,
-  whatsappFrom: String
+  whatsappFrom: String,
+  messagingServiceSid: String,
+  contentSid: String
 });
 
 export default mongoose.model('TwilioConfig', twilioConfigSchema);

--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -31,3 +31,38 @@ export async function sendWhatsApp(to, body) {
     direction: 'outbound',
   });
 }
+
+export async function sendAlarmWhatsApp(to, username, pointName) {
+  const config = await TwilioConfig.findOne();
+  if (!config) throw new Error('Config not found');
+  if (!config.messagingServiceSid || !config.contentSid) throw new Error('Alarm sender not configured');
+
+  const params = new URLSearchParams();
+  params.append('MessagingServiceSid', config.messagingServiceSid);
+  params.append('To', `whatsapp:${to}`);
+  params.append('ContentSid', config.contentSid);
+  params.append('ContentVariables', JSON.stringify({ 1: username, 2: pointName }));
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${config.accountSid}/Messages.json`;
+  const auth = Buffer.from(`${config.accountSid}:${config.authToken}`).toString('base64');
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: params.toString()
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text);
+  }
+
+  await TwilioMessage.create({
+    from: `messaging:${config.messagingServiceSid}`,
+    to: `whatsapp:${to}`,
+    body: `Alarma en ${pointName}`,
+    direction: 'outbound'
+  });
+}

--- a/webapp bot bms/frontend/src/pages/TwilioPage.jsx
+++ b/webapp bot bms/frontend/src/pages/TwilioPage.jsx
@@ -3,7 +3,13 @@ import { Container, Typography, TextField, Button, Box, Alert } from '@mui/mater
 import { fetchConfig, saveConfig } from '../services/twilio';
 
 export default function TwilioPage() {
-  const [config, setConfig] = useState({ accountSid: '', authToken: '', whatsappFrom: '' });
+  const [config, setConfig] = useState({
+    accountSid: '',
+    authToken: '',
+    whatsappFrom: '',
+    messagingServiceSid: '',
+    contentSid: ''
+  });
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -12,7 +18,9 @@ export default function TwilioPage() {
       if (res.data) setConfig({
         accountSid: res.data.accountSid || '',
         authToken: res.data.authToken || '',
-        whatsappFrom: res.data.whatsappFrom || ''
+        whatsappFrom: res.data.whatsappFrom || '',
+        messagingServiceSid: res.data.messagingServiceSid || '',
+        contentSid: res.data.contentSid || ''
       });
     });
   }, []);
@@ -39,6 +47,8 @@ export default function TwilioPage() {
         <TextField label="Account SID" value={config.accountSid} onChange={e=>setConfig(c=>({...c, accountSid:e.target.value}))} />
         <TextField label="Auth Token" value={config.authToken} onChange={e=>setConfig(c=>({...c, authToken:e.target.value}))} />
         <TextField label="WhatsApp From" value={config.whatsappFrom} onChange={e=>setConfig(c=>({...c, whatsappFrom:e.target.value}))} />
+        <TextField label="Service SID alarmas" value={config.messagingServiceSid} onChange={e=>setConfig(c=>({...c, messagingServiceSid:e.target.value}))} />
+        <TextField label="Content SID alarmas" value={config.contentSid} onChange={e=>setConfig(c=>({...c, contentSid:e.target.value}))} />
         <Button variant="contained" onClick={handleSave}>Guardar</Button>
       </Box>
       {/* Removed test message and received messages sections */}


### PR DESCRIPTION
## Summary
- extend Twilio config model to store WhatsApp sender service
- expose new fields in API and Twilio page
- add service helper to send alarms using Messaging Service
- use new alarm sender when alarms trigger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688167c9968083308825b869046ea834