### PR TITLE
Add alarm name and point group filter

### DIFF
--- a/webapp bot bms/backend/models/Alarm.js
+++ b/webapp bot bms/backend/models/Alarm.js
@@ -1,6 +1,7 @@
 import mongoose from '../config/database.js';
 
 const alarmSchema = new mongoose.Schema({
+  alarmName: { type: String, required: true },
   pointId: { type: mongoose.Schema.Types.ObjectId, ref: 'Point', required: true },
   groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group', required: true },
   conditionType: { type: String, enum: ['true', 'false', 'gt', 'lt'], required: true },


### PR DESCRIPTION
## Summary
- add `alarmName` at the top of Alarm schema
- update `AlarmsPage` UI and logic
  - show page title before filters
  - allow entering a name when creating an alarm
  - add group filter for point selection
  - fetch points by selected group

## Testing
- `npm test --prefix 'webapp bot bms'` *(fails: no test specified)*
- `npm run lint --prefix 'webapp bot bms'/frontend` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_688171f613e08330b4aa29dd1afeb7fc