### PR TITLE
Compute client connection state from last report time

### DIFF
--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -8,6 +8,15 @@ function generateApiKey() {
 export const getClients = async (req, res) => {
   try {
     const clients = await Client.find();
+    const now = Date.now();
+    for (const client of clients) {
+      const connected =
+        client.lastReport && now - client.lastReport.getTime() <= 60000;
+      if (client.connectionStatus !== connected) {
+        client.connectionStatus = connected;
+        await client.save();
+      }
+    }
     res.json(clients);
   } catch (err) {
     res.status(500).json({ message: 'Error al obtener clientes' });

--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -22,6 +22,10 @@ export const reportState = async (req, res) => {
       return res.status(400).json({ message: 'points es requerido' });
     }
 
+    client.lastReport = new Date();
+    client.connectionStatus = true;
+    await client.save();
+
     for (const p of points) {
       const { pointName, ipAddress, pointType, pointId, presentValue } = p;
 

--- a/webapp bot bms/backend/models/Client.js
+++ b/webapp bot bms/backend/models/Client.js
@@ -7,7 +7,8 @@ const clientSchema = new mongoose.Schema({
   ipAddress: String,
   location: String,
   groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
-  connectionStatus: { type: Boolean, default: false }
+  connectionStatus: { type: Boolean, default: false },
+  lastReport: Date
 });
 
 export default mongoose.model('Client', clientSchema);


### PR DESCRIPTION
## Summary
- track each client's last report time and set connection status accordingly
- update client documents on report and when fetching to reflect connectivity

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ae7b3fc883309253bebcb8c7ac2b