### PR TITLE
Disable client data processing when disabled

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -17,6 +17,11 @@ export const reportState = async (req, res) => {
     if (!client) {
       return res.status(401).json({ message: 'apiKey inválido' });
     }
+    if (!client.enabled) {
+      client.connectionStatus = false;
+      await client.save();
+      return res.status(403).json({ message: 'Cliente deshabilitado' });
+    }
 
     if (!Array.isArray(points) || points.length === 0) {
       return res.status(400).json({ message: 'points es requerido' });
@@ -122,4 +127,3 @@ export const getPoints = async (req, res) => {
     res.status(500).json({ message: 'Error al obtener puntos' });
   }
 };
-

--- a/webapp bot bms/frontend/src/pages/ClientPage.jsx
+++ b/webapp bot bms/frontend/src/pages/ClientPage.jsx
@@ -34,7 +34,7 @@ export default function ClientPage() {
       setClients(data);
       setNewClient({ clientName: '', location: '', groupId: '' });
       setError('');
-    } catch (err) {
+    } catch {
       setError('Error al crear cliente');
     }
   };
@@ -44,7 +44,7 @@ export default function ClientPage() {
       await deleteClient(deleteId);
       const { data } = await fetchClients();
       setClients(data);
-    } catch (err) {
+    } catch {
       setError('Error al eliminar cliente');
     } finally {
       setDeleteId(null);
@@ -56,7 +56,7 @@ export default function ClientPage() {
       await updateClientEnabled(toggleInfo.id, toggleInfo.enabled);
       const { data } = await fetchClients();
       setClients(data);
-    } catch (err) {
+    } catch {
       setError('Error al actualizar cliente');
     } finally {
       setToggleInfo(null);
@@ -94,7 +94,10 @@ export default function ClientPage() {
                 <TableCell>{c.location}</TableCell>
                 <TableCell>{groups.find(g => g._id === c.groupId)?.groupName || c.groupId}</TableCell>
                 <TableCell>
-                  <FiberManualRecord sx={{ color: c.connectionStatus ? 'green' : 'red' }} />
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <FiberManualRecord sx={{ color: c.connectionStatus ? 'green' : 'red' }} />
+                    {c.lastReport ? new Date(c.lastReport).toLocaleString() : 'Sin conexión'}
+                  </Box>
                 </TableCell>
                 <TableCell>
                   <IconButton color="error" onClick={() => setDeleteId(c._id)}>

--- a/webapp bot bms/frontend/src/pages/GroupPage.jsx
+++ b/webapp bot bms/frontend/src/pages/GroupPage.jsx
@@ -26,7 +26,7 @@ export default function GroupPage() {
       setGroups(data);
       setNewGroup({ groupName: '', description: '' });
       setError('');
-    } catch (err) {
+    } catch {
       setError('Error al crear grupo');
     }
   };
@@ -36,7 +36,7 @@ export default function GroupPage() {
       await deleteGroup(deleteId);
       const { data } = await fetchGroups();
       setGroups(data);
-    } catch (err) {
+    } catch {
       setError('Error al eliminar grupo');
     } finally {
       setDeleteId(null);

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -40,7 +40,7 @@ export default function UsuariosPage() {
       await deleteUser(deleteId);
       const { data } = await fetchUsers();
       setUsers(data);
-    } catch (err) {
+    } catch {
       setError('Error al eliminar usuario');
     } finally {
       setDeleteId(null);


### PR DESCRIPTION
## Summary
- Stop processing and alarms for disabled clients on the server
- Show last connection time in client list
- Clean up unused variables in pages to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68c7b0c07840833083172254e350019e