### PR TITLE
Use alarm name as WhatsApp alert message

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -61,7 +61,7 @@ export const reportState = async (req, res) => {
             for (const u of users) {
               if (u.phoneNum) {
                 try {
-                  await sendAlarmWhatsApp(u.phoneNum, u.username, point.pointName);
+                  await sendAlarmWhatsApp(u.phoneNum, alarm.alarmName);
                 } catch (e) {
                   console.error('Error enviando WhatsApp', e.message);
                 }

--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -32,16 +32,15 @@ export async function sendWhatsApp(to, body) {
   });
 }
 
-export async function sendAlarmWhatsApp(to, username, pointName) {
+export async function sendAlarmWhatsApp(to, message) {
   const config = await TwilioConfig.findOne();
   if (!config) throw new Error('Config not found');
-  if (!config.messagingServiceSid || !config.contentSid) throw new Error('Alarm sender not configured');
+  if (!config.messagingServiceSid) throw new Error('Alarm sender not configured');
 
   const params = new URLSearchParams();
   params.append('MessagingServiceSid', config.messagingServiceSid);
   params.append('To', `whatsapp:${to}`);
-  params.append('ContentSid', config.contentSid);
-  params.append('ContentVariables', JSON.stringify({ 1: username, 2: pointName }));
+  params.append('Body', message);
 
   const url = `https://api.twilio.com/2010-04-01/Accounts/${config.accountSid}/Messages.json`;
   const auth = Buffer.from(`${config.accountSid}:${config.authToken}`).toString('base64');
@@ -62,7 +61,7 @@ export async function sendAlarmWhatsApp(to, username, pointName) {
   await TwilioMessage.create({
     from: `messaging:${config.messagingServiceSid}`,
     to: `whatsapp:${to}`,
-    body: `Alarma en ${pointName}`,
+    body: message,
     direction: 'outbound'
   });
 }


### PR DESCRIPTION
## Summary
- send WhatsApp alarm messages using the alarm name text
- trigger alarm notifications with the configured alarm name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b87335b08330853ceb30363fabef