### PR TITLE
feat: add tendencias page with datalog trends

### DIFF
--- a/webapp bot bms/backend/controllers/dataLogController.js
+++ b/webapp bot bms/backend/controllers/dataLogController.js
@@ -1,0 +1,15 @@
+import DataLog from '../models/DataLog.js';
+
+export const getDataLogs = async (req, res) => {
+  try {
+    const { pointId } = req.query;
+    if (!pointId) {
+      return res.status(400).json({ message: 'pointId requerido' });
+    }
+    const logs = await DataLog.find({ pointId }).sort({ timestamp: 1 }).lean();
+    res.json(logs);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al obtener datalogs' });
+  }
+};

--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -8,6 +8,7 @@ import groupRoutes from './routes/groupRoutes.js';
 import pointRoutes from './routes/pointRoutes.js';
 import twilioRoutes from './routes/twilioRoutes.js';
 import alarmRoutes from './routes/alarmRoutes.js';
+import dataLogRoutes from './routes/dataLogRoutes.js';
 
 const app = express();
 app.use(cors());
@@ -19,5 +20,6 @@ app.use('/api', groupRoutes);
 app.use('/api', pointRoutes);
 app.use('/api', twilioRoutes);
 app.use('/api', alarmRoutes);
+app.use('/api', dataLogRoutes);
 
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/backend/routes/dataLogRoutes.js
+++ b/webapp bot bms/backend/routes/dataLogRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getDataLogs } from '../controllers/dataLogController.js';
+
+const router = express.Router();
+
+router.get('/datalogs', getDataLogs);
+
+export default router;

--- a/webapp bot bms/frontend/package.json
+++ b/webapp bot bms/frontend/package.json
@@ -17,7 +17,8 @@
     "axios": "^1.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "recharts": "^2.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -9,7 +9,8 @@ import ClientPage from './pages/ClientPage';
 import TwilioPage from './pages/TwilioPage';
 import WhatsappPage from './pages/WhatsappPage';
 import AlarmsPage from './pages/AlarmsPage';
-import Layout from './components/Layout'; 
+import TendenciasPage from './pages/TendenciasPage';
+import Layout from './components/Layout';
 import { useAuth } from './context/AuthContext';
 
 function PrivateRoute({ children }) {
@@ -67,6 +68,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <AlarmsPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/tendencias"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <TendenciasPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -7,6 +7,7 @@ import DevicesIcon from '@mui/icons-material/Devices';
 import ChatIcon from '@mui/icons-material/Chat';
 import WhatsAppIcon from '@mui/icons-material/WhatsApp';
 import AlarmIcon from '@mui/icons-material/NotificationsActive';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -41,6 +42,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/alarmas" activeClassName="Mui-selected" exact>
           <ListItemIcon><AlarmIcon /></ListItemIcon>
           <ListItemText primary="Alarmas" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/tendencias" activeClassName="Mui-selected" exact>
+          <ListItemIcon><ShowChartIcon /></ListItemIcon>
+          <ListItemText primary="Tendencias" />
         </ListItemButton>
         <ListItemButton component={NavLink} to="/twilio" activeClassName="Mui-selected" exact>
           <ListItemIcon><ChatIcon /></ListItemIcon>

--- a/webapp bot bms/frontend/src/pages/TendenciasPage.jsx
+++ b/webapp bot bms/frontend/src/pages/TendenciasPage.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { fetchPoints } from '../services/points';
+import { fetchDataLogs } from '../services/datalogs';
+
+export default function TendenciasPage() {
+  const [points, setPoints] = useState([]);
+  const [selectedPoint, setSelectedPoint] = useState('');
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    fetchPoints()
+      .then((res) => setPoints(res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const handlePointChange = (e) => {
+    const id = e.target.value;
+    setSelectedPoint(id);
+    if (id) {
+      fetchDataLogs(id)
+        .then((res) => setLogs(res.data))
+        .catch((err) => console.error(err));
+    } else {
+      setLogs([]);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Tendencias
+      </Typography>
+      <FormControl fullWidth sx={{ mb: 3 }}>
+        <InputLabel id="point-select-label">Punto</InputLabel>
+        <Select
+          labelId="point-select-label"
+          value={selectedPoint}
+          label="Punto"
+          onChange={handlePointChange}
+        >
+          {points.map((p) => (
+            <MenuItem key={p._id} value={p._id}>
+              {p.pointName}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      {logs.length > 0 && (
+        <ResponsiveContainer width="100%" height={400}>
+          <LineChart data={logs}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(t) => new Date(t).toLocaleTimeString()}
+            />
+            <YAxis />
+            <Tooltip labelFormatter={(label) => new Date(label).toLocaleString()} />
+            <Line type="monotone" dataKey="presentValue" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </Box>
+  );
+}

--- a/webapp bot bms/frontend/src/services/datalogs.js
+++ b/webapp bot bms/frontend/src/services/datalogs.js
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+export const fetchDataLogs = (pointId) => axios.get('/api/datalogs', { params: { pointId } });


### PR DESCRIPTION
## Summary
- serve datalog history via new `/api/datalogs` endpoint
- add Tendencias page with selectable point trend chart
- link Tendencias page in sidebar navigation

## Testing
- `npm run lint` *(frontend warning: Fast refresh only works when a file only exports components)*
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bbf074ec8330ba7baa7561ef0491