### PR TITLE
Use Chart.js with zoom and date filters

### DIFF
--- a/webapp bot bms/frontend/index.html
+++ b/webapp bot bms/frontend/index.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
+    <script>
+      if (window.Chart && window.ChartZoom) {
+        window.Chart.register(window.ChartZoom);
+      }
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace Recharts trend graph with Chart.js, add zoom plugin and date range filters
- Load Chart.js from CDN and initialize zoom plugin

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7bebcd2088330a5c701ee27815c20