### PR TITLE
Fix Twilio alarm WhatsApp template parameters

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -63,7 +63,7 @@ export const reportState = async (req, res) => {
             for (const u of users) {
               if (u.phoneNum) {
                 try {
-                  await sendAlarmWhatsApp(u.phoneNum, alarm.alarmName);
+                  await sendAlarmWhatsApp(u.phoneNum, u.username, alarm.alarmName);
                 } catch (e) {
                   console.error('Error enviando WhatsApp', e.message);
                 }


### PR DESCRIPTION
## Summary
- restore the Twilio alarm WhatsApp helper to use the messaging template content SID with username and alarm name variables
- pass the user's name when dispatching alarm notifications so the template variables are populated correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0d32030b08330af01d2ad9e5c6710