### PR TITLE
Add interactive alarm notifications to top bar

### DIFF
--- a/webapp bot bms/frontend/src/components/TopBar.jsx
+++ b/webapp bot bms/frontend/src/components/TopBar.jsx
@@ -1,22 +1,113 @@
-import React from 'react';
-import { AppBar, Toolbar, IconButton, Badge, Menu, MenuItem, Typography, Box } from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  Badge,
+  Menu,
+  MenuItem,
+  Typography,
+  Box,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Tooltip,
+  CircularProgress,
+} from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import { useAuth } from '../context/AuthContext';
+import { fetchAlarms } from '../services/alarms';
 
 export default function TopBar() {
   const { logout } = useAuth();
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [userMenuAnchorEl, setUserMenuAnchorEl] = useState(null);
+  const [notificationsAnchorEl, setNotificationsAnchorEl] = useState(null);
+  const [alarms, setAlarms] = useState([]);
+  const [loadingAlarms, setLoadingAlarms] = useState(false);
+  const [alarmsError, setAlarmsError] = useState('');
+  const isMounted = useRef(false);
 
-  const handleMenu = (event) => {
-    setAnchorEl(event.currentTarget);
+  const activeAlarmsCount = useMemo(
+    () => alarms.filter((alarm) => alarm.active).length,
+    [alarms],
+  );
+
+  const formatCondition = (alarm) => {
+    switch (alarm.conditionType) {
+      case 'gt':
+        return `>= ${alarm.threshold ?? '-'}`;
+      case 'lt':
+        return `<= ${alarm.threshold ?? '-'}`;
+      case 'true':
+        return '== true';
+      case 'false':
+        return '== false';
+      default:
+        return 'Condición desconocida';
+    }
   };
-  const handleClose = () => {
-    setAnchorEl(null);
+
+  const loadAlarms = useCallback(async () => {
+    if (!isMounted.current) {
+      return;
+    }
+
+    setLoadingAlarms(true);
+    try {
+      const { data } = await fetchAlarms();
+      if (!isMounted.current) {
+        return;
+      }
+
+      setAlarms(data);
+      setAlarmsError('');
+    } catch {
+      if (!isMounted.current) {
+        return;
+      }
+
+      setAlarms([]);
+      setAlarmsError('No se pudieron cargar las alarmas.');
+    } finally {
+      if (isMounted.current) {
+        setLoadingAlarms(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMounted.current = true;
+    loadAlarms();
+    const intervalId = setInterval(loadAlarms, 30000);
+
+    return () => {
+      isMounted.current = false;
+      clearInterval(intervalId);
+    };
+  }, [loadAlarms]);
+
+  const handleUserMenuOpen = (event) => {
+    setUserMenuAnchorEl(event.currentTarget);
   };
+
+  const handleUserMenuClose = () => {
+    setUserMenuAnchorEl(null);
+  };
+
   const handleLogout = () => {
-    handleClose();
+    handleUserMenuClose();
     logout();
+  };
+
+  const handleNotificationsOpen = (event) => {
+    setNotificationsAnchorEl(event.currentTarget);
+    loadAlarms();
+  };
+
+  const handleNotificationsClose = () => {
+    setNotificationsAnchorEl(null);
   };
 
   return (
@@ -32,20 +123,105 @@ export default function TopBar() {
           FusionBMS
           <Box component="img" src="/icons/isologo-100x100.png" alt="FusionBMS" sx={{ height: 24, width: 24, ml: 1 }} />
         </Typography>
-        <IconButton color="inherit">
-          <Badge badgeContent={4} color="error">
-            <NotificationsIcon />
-          </Badge>
-        </IconButton>
-        <IconButton color="inherit" onClick={handleMenu}>
+        <Tooltip title="Alarmas">
+          <IconButton
+            color="inherit"
+            onClick={handleNotificationsOpen}
+            aria-controls={notificationsAnchorEl ? 'notifications-menu' : undefined}
+            aria-haspopup="true"
+          >
+            <Badge badgeContent={activeAlarmsCount} color={activeAlarmsCount > 0 ? 'error' : 'default'} max={99} showZero>
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+        </Tooltip>
+        <IconButton
+          color="inherit"
+          onClick={handleUserMenuOpen}
+          aria-controls={userMenuAnchorEl ? 'user-menu' : undefined}
+          aria-haspopup="true"
+        >
           <AccountCircle />
         </IconButton>
         <Menu
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={handleClose}
+          id="user-menu"
+          anchorEl={userMenuAnchorEl}
+          open={Boolean(userMenuAnchorEl)}
+          onClose={handleUserMenuClose}
         >
           <MenuItem onClick={handleLogout}>Cerrar sesión</MenuItem>
+        </Menu>
+        <Menu
+          id="notifications-menu"
+          anchorEl={notificationsAnchorEl}
+          open={Boolean(notificationsAnchorEl)}
+          onClose={handleNotificationsClose}
+          MenuListProps={{
+            dense: true,
+            sx: { width: '100%' },
+          }}
+          PaperProps={{
+            sx: {
+              width: 320,
+              maxHeight: 360,
+              p: 1,
+            },
+          }}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        >
+          <Box sx={{ px: 1.5, py: 1 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              Alarmas
+            </Typography>
+          </Box>
+          <Divider />
+          <Box sx={{ px: 1.5, py: 1 }}>
+            {loadingAlarms ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                <CircularProgress size={24} color="inherit" />
+              </Box>
+            ) : alarmsError ? (
+              <Typography variant="body2" color="error" sx={{ textAlign: 'center' }}>
+                {alarmsError}
+              </Typography>
+            ) : alarms.length === 0 ? (
+              <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                No hay alarmas registradas.
+              </Typography>
+            ) : (
+              <List dense sx={{ py: 0 }}>
+                {alarms.map((alarm) => (
+                  <ListItem key={alarm._id} alignItems="flex-start" sx={{ px: 0, py: 1 }}>
+                    <ListItemText
+                      primary={(
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                          {alarm.alarmName}
+                        </Typography>
+                      )}
+                      secondary={(
+                        <>
+                          <Typography variant="body2" color="text.secondary">
+                            Punto: {alarm.pointId?.pointName || alarm.pointId || 'Sin asignar'}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            Grupo: {alarm.groupId?.groupName || alarm.groupId || 'Sin asignar'}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color={alarm.active ? 'error.main' : 'text.secondary'}
+                            sx={{ mt: 0.5, display: 'block' }}
+                          >
+                            {alarm.active ? 'Activa' : 'Inactiva'} — {formatCondition(alarm)}
+                          </Typography>
+                        </>
+                      )}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </Box>
         </Menu>
       </Toolbar>
     </AppBar>


### PR DESCRIPTION
## Summary
- fetch alarm data on an interval in the top bar and keep track of active alarms
- show the active alarm count in the notifications badge and refresh when the icon is opened
- display a notifications dropdown with alarm details, loading state, and error messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0dcd3898c8330ac83c70de6f0def9