### PR TITLE
Fix storing empty alarm WhatsApp messages

### DIFF
--- a/webapp bot bms/backend/controllers/twilioController.js
+++ b/webapp bot bms/backend/controllers/twilioController.js
@@ -55,6 +55,7 @@ export const sendMessage = async (req, res) => {
     const data = await response.json();
 
     await TwilioMessage.create({
+      sid: data.sid,
       from: `whatsapp:${config.whatsappFrom}`,
       to: `whatsapp:${to}`,
       body,
@@ -73,6 +74,7 @@ export const twilioWebhook = async (req, res) => {
     const { From, To, Body } = req.body;
     if (From && Body) {
       await TwilioMessage.create({
+        sid: req.body.MessageSid,
         from: From,
         to: To,
         body: Body,

--- a/webapp bot bms/backend/models/TwilioMessage.js
+++ b/webapp bot bms/backend/models/TwilioMessage.js
@@ -1,6 +1,7 @@
 import mongoose from '../config/database.js';
 
 const twilioMessageSchema = new mongoose.Schema({
+  sid: String,
   from: String,
   to: String,
   body: String,

--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -24,7 +24,11 @@ export async function sendWhatsApp(to, body) {
     const text = await response.text();
     throw new Error(text);
   }
+
+  const createdMessage = await response.json();
+
   await TwilioMessage.create({
+    sid: createdMessage.sid,
     from: `whatsapp:${config.whatsappFrom}`,
     to: `whatsapp:${to}`,
     body,
@@ -75,11 +79,15 @@ export async function sendAlarmWhatsApp(to, username, alarmName) {
   }
 
   const messageDetails = await messageDetailsResponse.json();
+  const fallbackBody = (messageDetails.body ?? '').trim().length > 0
+    ? messageDetails.body
+    : `Alarma "${alarmName}" reportada para ${username}`;
 
   await TwilioMessage.create({
+    sid: createdMessage.sid,
     from: messageDetails.from ?? `messaging:${config.messagingServiceSid}`,
     to: `whatsapp:${to}`,
-    body: messageDetails.body ?? JSON.stringify({ contentSid: config.contentSid, variables: { 1: username, 2: alarmName } }),
+    body: fallbackBody,
     direction: 'outbound'
   });
 }


### PR DESCRIPTION
## Summary
- add the Twilio SID to stored WhatsApp messages
- persist the SID for outbound and inbound messages when sending via API and webhooks
- fetch message details for alarm notifications and store a fallback message when the body is empty

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0e51340dc8330851ad7e093392bd6