### PR TITLE
Notify WhatsApp on client reconnection

### DIFF
--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -101,3 +101,8 @@ export async function sendClientOfflineWhatsApp(to, username, clientName) {
   const offlineMessage = `Cliente "${clientName}" fuera de linea`;
   await sendTemplatedWhatsApp(to, username, offlineMessage, offlineMessage);
 }
+
+export async function sendClientOnlineWhatsApp(to, username, clientName) {
+  const onlineMessage = `Cliente "${clientName}" en linea`;
+  await sendTemplatedWhatsApp(to, username, onlineMessage, onlineMessage);
+}


### PR DESCRIPTION
## Summary
- send a WhatsApp alert when a client transitions from offline to online status
- reuse shared notification logic when connection status changes for consistency
- add Twilio service helper for the client reconnection WhatsApp template

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0ffc6691c8330891020424572c56f