### PR TITLE
Add event entity and events page

### DIFF
--- a/webapp bot bms/backend/controllers/eventController.js
+++ b/webapp bot bms/backend/controllers/eventController.js
@@ -1,0 +1,38 @@
+import Event from '../models/Event.js';
+
+export const getEvents = async (req, res) => {
+  try {
+    const { page = 1, limit = 20, groupId } = req.query;
+    const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
+    const limitNumber = Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100);
+
+    const filter = {};
+    if (groupId) {
+      filter.groupId = groupId;
+    }
+
+    const [events, total] = await Promise.all([
+      Event.find(filter)
+        .populate({ path: 'pointId', select: 'pointName' })
+        .populate({ path: 'groupId', select: 'groupName' })
+        .sort({ timestamp: -1 })
+        .skip((pageNumber - 1) * limitNumber)
+        .limit(limitNumber)
+        .lean(),
+      Event.countDocuments(filter),
+    ]);
+
+    res.json({
+      data: events,
+      pagination: {
+        total,
+        page: pageNumber,
+        limit: limitNumber,
+        totalPages: total > 0 ? Math.ceil(total / limitNumber) : 0,
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al obtener eventos' });
+  }
+};

--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -2,6 +2,7 @@ import Client from '../models/Client.js';
 import Point from '../models/Point.js';
 import DataLog from '../models/DataLog.js';
 import Alarm from '../models/Alarm.js';
+import Event from '../models/Event.js';
 import User from '../models/User.js';
 import { sendAlarmWhatsApp } from '../services/twilioService.js';
 
@@ -70,6 +71,16 @@ export const reportState = async (req, res) => {
 
         if (triggered) {
           if (!alarm.active) {
+            try {
+              await Event.create({
+                eventType: 'Alarm',
+                pointId: point._id,
+                presentValue,
+                groupId: point.groupId || client.groupId || undefined,
+              });
+            } catch (e) {
+              console.error('Error registrando evento', e.message);
+            }
             const users = await User.find({ groupId: alarm.groupId });
             for (const u of users) {
               if (u.phoneNum) {

--- a/webapp bot bms/backend/index.js
+++ b/webapp bot bms/backend/index.js
@@ -9,6 +9,7 @@ import pointRoutes from './routes/pointRoutes.js';
 import twilioRoutes from './routes/twilioRoutes.js';
 import alarmRoutes from './routes/alarmRoutes.js';
 import dataLogRoutes from './routes/dataLogRoutes.js';
+import eventRoutes from './routes/eventRoutes.js';
 
 const app = express();
 app.use(cors());
@@ -21,5 +22,6 @@ app.use('/api', pointRoutes);
 app.use('/api', twilioRoutes);
 app.use('/api', alarmRoutes);
 app.use('/api', dataLogRoutes);
+app.use('/api', eventRoutes);
 
 app.listen(3000, () => console.log('API corriendo en http://localhost:3000'));

--- a/webapp bot bms/backend/models/Event.js
+++ b/webapp bot bms/backend/models/Event.js
@@ -1,0 +1,11 @@
+import mongoose from '../config/database.js';
+
+const eventSchema = new mongoose.Schema({
+  eventType: { type: String, required: true },
+  pointId: { type: mongoose.Schema.Types.ObjectId, ref: 'Point', required: true },
+  presentValue: mongoose.Schema.Types.Mixed,
+  groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
+  timestamp: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('Event', eventSchema);

--- a/webapp bot bms/backend/routes/eventRoutes.js
+++ b/webapp bot bms/backend/routes/eventRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getEvents } from '../controllers/eventController.js';
+
+const router = express.Router();
+
+router.get('/events', getEvents);
+
+export default router;

--- a/webapp bot bms/frontend/src/App.jsx
+++ b/webapp bot bms/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import TwilioPage from './pages/TwilioPage';
 import WhatsappPage from './pages/WhatsappPage';
 import AlarmsPage from './pages/AlarmsPage';
 import TendenciasPage from './pages/TendenciasPage';
+import EventosPage from './pages/EventosPage';
 import Layout from './components/Layout';
 import { useAuth } from './context/AuthContext';
 
@@ -78,6 +79,16 @@ export default function App() {
           <PrivateRoute>
             <Layout>
               <TendenciasPage />
+            </Layout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/eventos"
+        element={
+          <PrivateRoute>
+            <Layout>
+              <EventosPage />
             </Layout>
           </PrivateRoute>
         }

--- a/webapp bot bms/frontend/src/components/Sidebar.jsx
+++ b/webapp bot bms/frontend/src/components/Sidebar.jsx
@@ -8,6 +8,7 @@ import ChatIcon from '@mui/icons-material/Chat';
 import WhatsAppIcon from '@mui/icons-material/WhatsApp';
 import AlarmIcon from '@mui/icons-material/NotificationsActive';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
+import EventNoteIcon from '@mui/icons-material/EventNote';
 import { NavLink } from 'react-router-dom';
 
 const drawerWidth = 240;
@@ -46,6 +47,10 @@ export default function Sidebar() {
         <ListItemButton component={NavLink} to="/tendencias" activeClassName="Mui-selected" exact>
           <ListItemIcon><ShowChartIcon /></ListItemIcon>
           <ListItemText primary="Tendencias" />
+        </ListItemButton>
+        <ListItemButton component={NavLink} to="/eventos" activeClassName="Mui-selected" exact>
+          <ListItemIcon><EventNoteIcon /></ListItemIcon>
+          <ListItemText primary="Eventos" />
         </ListItemButton>
         <ListItemButton component={NavLink} to="/twilio" activeClassName="Mui-selected" exact>
           <ListItemIcon><ChatIcon /></ListItemIcon>

--- a/webapp bot bms/frontend/src/pages/EventosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/EventosPage.jsx
@@ -1,0 +1,156 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TablePagination,
+  Chip,
+  CircularProgress,
+} from '@mui/material';
+import { fetchGroups } from '../services/groups';
+import { fetchEvents } from '../services/events';
+
+export default function EventosPage() {
+  const [groups, setGroups] = useState([]);
+  const [groupId, setGroupId] = useState('');
+  const [events, setEvents] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchGroups()
+      .then((res) => setGroups(res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const loadEvents = useCallback(() => {
+    setLoading(true);
+    fetchEvents({ page: page + 1, limit: rowsPerPage, groupId: groupId || undefined })
+      .then((res) => {
+        setEvents(res.data.data);
+        setTotal(res.data.pagination.total);
+      })
+      .catch((err) => {
+        console.error(err);
+        setEvents([]);
+        setTotal(0);
+      })
+      .finally(() => setLoading(false));
+  }, [groupId, page, rowsPerPage]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
+
+  const handleGroupChange = (event) => {
+    setGroupId(event.target.value);
+    setPage(0);
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Eventos
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel id="group-filter-label">Grupo</InputLabel>
+          <Select
+            labelId="group-filter-label"
+            value={groupId}
+            label="Grupo"
+            onChange={handleGroupChange}
+          >
+            <MenuItem value="">Todos</MenuItem>
+            {groups.map((g) => (
+              <MenuItem key={g._id} value={g._id}>
+                {g.groupName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Paper sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table sx={{ minWidth: 900 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Tipo</TableCell>
+              <TableCell>Punto</TableCell>
+              <TableCell>Valor</TableCell>
+              <TableCell>Grupo</TableCell>
+              <TableCell>Fecha y hora</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center">
+                  <CircularProgress size={24} />
+                </TableCell>
+              </TableRow>
+            ) : events.length > 0 ? (
+              events.map((event) => (
+                <TableRow key={event._id}>
+                  <TableCell>
+                    <Chip label={event.eventType} color="primary" size="small" />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {event.pointId?.pointName || 'N/A'}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {event.pointId?._id || 'Sin ID'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>{event.presentValue ?? 'N/A'}</TableCell>
+                  <TableCell>{event.groupId?.groupName || 'Sin grupo'}</TableCell>
+                  <TableCell>
+                    {event.timestamp
+                      ? new Date(event.timestamp).toLocaleString()
+                      : 'N/A'}
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={5} align="center">
+                  No hay eventos registrados.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={total}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={[10, 25, 50]}
+          labelRowsPerPage="Filas por página"
+        />
+      </Paper>
+    </Box>
+  );
+}

--- a/webapp bot bms/frontend/src/services/events.js
+++ b/webapp bot bms/frontend/src/services/events.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export const fetchEvents = ({ page = 1, limit = 10, groupId } = {}) => {
+  const params = { page, limit };
+  if (groupId) {
+    params.groupId = groupId;
+  }
+  return axios.get('/api/events', { params });
+};


### PR DESCRIPTION
## Summary
- add an Event mongoose schema, REST controller and route, and persist alarm activations as events
- expose the events endpoint through the API server and a frontend service
- add an "Eventos" page with group filtering, pagination and navigation entry to list stored events

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32237160c8330a9e83f56557d9cd5