### PR TITLE
Refactor group relationships and update client handling

### DIFF
--- a/webapp bot bms/backend/controllers/groupController.js
+++ b/webapp bot bms/backend/controllers/groupController.js
@@ -1,8 +1,40 @@
+import mongoose from 'mongoose';
 import Group from '../models/Group.js';
+import User from '../models/User.js';
+import Point from '../models/Point.js';
+
+const normalizeIds = (values) => {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set();
+  const result = [];
+  values.forEach((value) => {
+    if (!value) return;
+    try {
+      const objectId = new mongoose.Types.ObjectId(value);
+      const key = objectId.toString();
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(objectId);
+      }
+    } catch (err) {
+      // Ignore invalid ids
+    }
+  });
+  return result;
+};
+
+const populateGroup = (query) =>
+  query
+    .populate({ path: 'users', select: 'username name phoneNum userType' })
+    .populate({
+      path: 'points',
+      select: 'pointName pointId clientId',
+      populate: { path: 'clientId', select: 'clientName' },
+    });
 
 export const getGroups = async (req, res) => {
   try {
-    const groups = await Group.find();
+    const groups = await populateGroup(Group.find());
     res.json(groups);
   } catch (err) {
     res.status(500).json({ message: 'Error al obtener grupos' });
@@ -11,8 +43,45 @@ export const getGroups = async (req, res) => {
 
 export const createGroup = async (req, res) => {
   try {
-    const newGroup = await Group.create(req.body);
-    res.status(201).json(newGroup);
+    const { users, points, ...rest } = req.body || {};
+    const userIds = normalizeIds(users);
+    const pointIds = normalizeIds(points);
+
+    const group = new Group(rest);
+    group.users = userIds;
+    group.points = pointIds;
+    await group.save();
+
+    const promises = [];
+
+    if (userIds.length > 0) {
+      const userObjectIds = userIds.map((id) => id);
+      promises.push(
+        Group.updateMany(
+          { _id: { $ne: group._id }, users: { $in: userObjectIds } },
+          { $pull: { users: { $in: userObjectIds } } }
+        )
+      );
+      promises.push(User.updateMany({ _id: { $in: userObjectIds } }, { groupId: group._id }));
+    }
+
+    if (pointIds.length > 0) {
+      const pointObjectIds = pointIds.map((id) => id);
+      promises.push(
+        Group.updateMany(
+          { _id: { $ne: group._id }, points: { $in: pointObjectIds } },
+          { $pull: { points: { $in: pointObjectIds } } }
+        )
+      );
+      promises.push(Point.updateMany({ _id: { $in: pointObjectIds } }, { groupId: group._id }));
+    }
+
+    if (promises.length > 0) {
+      await Promise.all(promises);
+    }
+
+    const populated = await populateGroup(Group.findById(group._id));
+    res.status(201).json(populated);
   } catch (err) {
     res.status(500).json({ message: 'Error al crear grupo' });
   }
@@ -20,14 +89,96 @@ export const createGroup = async (req, res) => {
 
 export const updateGroup = async (req, res) => {
   try {
-    const updatedGroup = await Group.findByIdAndUpdate(req.params.id, req.body, {
-      new: true,
-      runValidators: true,
-    });
-    if (!updatedGroup) {
+    const group = await Group.findById(req.params.id);
+    if (!group) {
       return res.status(404).json({ message: 'Grupo no encontrado' });
     }
-    res.json(updatedGroup);
+
+    const { users, points, ...rest } = req.body || {};
+
+    Object.entries(rest).forEach(([key, value]) => {
+      if (typeof value !== 'undefined') {
+        group[key] = value;
+      }
+    });
+
+    const operations = [];
+
+    if (Array.isArray(users)) {
+      const normalizedUsers = normalizeIds(users);
+      const previousUsers = (group.users || []).map((id) => id.toString());
+      const nextUsers = normalizedUsers.map((id) => id.toString());
+
+      const removedUsers = previousUsers.filter((id) => !nextUsers.includes(id));
+      const addedUsers = nextUsers.filter((id) => !previousUsers.includes(id));
+
+      group.users = normalizedUsers;
+
+      if (removedUsers.length > 0) {
+        operations.push(
+          User.updateMany(
+            { _id: { $in: removedUsers }, groupId: group._id },
+            { $unset: { groupId: '' } }
+          )
+        );
+      }
+
+      if (addedUsers.length > 0) {
+        const addedObjectIds = addedUsers.map((id) => new mongoose.Types.ObjectId(id));
+        operations.push(
+          Group.updateMany(
+            { _id: { $ne: group._id }, users: { $in: addedObjectIds } },
+            { $pull: { users: { $in: addedObjectIds } } }
+          )
+        );
+        operations.push(
+          User.updateMany(
+            { _id: { $in: addedUsers } },
+            { groupId: group._id }
+          )
+        );
+      }
+    }
+
+    if (Array.isArray(points)) {
+      const normalizedPoints = normalizeIds(points);
+      const previousPoints = (group.points || []).map((id) => id.toString());
+      const nextPoints = normalizedPoints.map((id) => id.toString());
+
+      const removedPoints = previousPoints.filter((id) => !nextPoints.includes(id));
+      const addedPoints = nextPoints.filter((id) => !previousPoints.includes(id));
+
+      group.points = normalizedPoints;
+
+      if (removedPoints.length > 0) {
+        operations.push(
+          Point.updateMany(
+            { _id: { $in: removedPoints }, groupId: group._id },
+            { $unset: { groupId: '' } }
+          )
+        );
+      }
+
+      if (addedPoints.length > 0) {
+        const addedObjectIds = addedPoints.map((id) => new mongoose.Types.ObjectId(id));
+        operations.push(
+          Group.updateMany(
+            { _id: { $ne: group._id }, points: { $in: addedObjectIds } },
+            { $pull: { points: { $in: addedObjectIds } } }
+          )
+        );
+        operations.push(Point.updateMany({ _id: { $in: addedPoints } }, { groupId: group._id }));
+      }
+    }
+
+    if (operations.length > 0) {
+      await Promise.all(operations);
+    }
+
+    await group.save();
+
+    const populated = await populateGroup(Group.findById(group._id));
+    res.json(populated);
   } catch (err) {
     res.status(500).json({ message: 'Error al actualizar grupo' });
   }
@@ -35,7 +186,14 @@ export const updateGroup = async (req, res) => {
 
 export const deleteGroup = async (req, res) => {
   try {
-    await Group.findByIdAndDelete(req.params.id);
+    const group = await Group.findByIdAndDelete(req.params.id);
+    if (group) {
+      const ids = group._id;
+      await Promise.all([
+        User.updateMany({ groupId: ids }, { $unset: { groupId: '' } }),
+        Point.updateMany({ groupId: ids }, { $unset: { groupId: '' } }),
+      ]);
+    }
     res.status(204).end();
   } catch (err) {
     res.status(500).json({ message: 'Error al eliminar grupo' });

--- a/webapp bot bms/backend/dbupdated.js
+++ b/webapp bot bms/backend/dbupdated.js
@@ -14,22 +14,30 @@ async function applyChanges() {
       console.log('Grupo existente:', group._id.toString());
     }
 
+    const groupId = group._id;
+
     // Create example points if none exist for the group
-    const points = await Point.find({ groupId: group._id });
+    const points = await Point.find({ groupId });
     if (points.length === 0) {
-      const samplePoints = [
-        { pointName: 'Punto 1', ipAddress: '192.168.0.10', pointType: 1, pointId: 1, groupId: group._id },
-        { pointName: 'Punto 2', ipAddress: '192.168.0.11', pointType: 2, pointId: 2, groupId: group._id }
-      ];
-      await Point.insertMany(samplePoints);
+      const samplePoints = await Point.insertMany([
+        { pointName: 'Punto 1', ipAddress: '192.168.0.10', pointType: 1, pointId: 1, groupId },
+        { pointName: 'Punto 2', ipAddress: '192.168.0.11', pointType: 2, pointId: 2, groupId }
+      ]);
       console.log('Puntos creados');
+      await Group.findByIdAndUpdate(groupId, { $addToSet: { points: { $each: samplePoints.map((p) => p._id) } } });
     } else {
       console.log('Puntos ya existen para el grupo');
+      const pointIds = points.map((p) => p._id);
+      await Group.findByIdAndUpdate(groupId, { $addToSet: { points: { $each: pointIds } } });
     }
 
     // Update users without groupId
-    const updated = await User.updateMany({ groupId: { $exists: false } }, { groupId: group._id });
+    const updated = await User.updateMany({ groupId: { $exists: false } }, { groupId: groupId });
     console.log('Usuarios actualizados:', updated.modifiedCount);
+    const usersWithGroup = await User.find({ groupId: groupId }).select('_id');
+    if (usersWithGroup.length > 0) {
+      await Group.findByIdAndUpdate(groupId, { $addToSet: { users: { $each: usersWithGroup.map((u) => u._id) } } });
+    }
   } catch (err) {
     console.error('Error durante la migración:', err);
   } finally {

--- a/webapp bot bms/backend/models/Client.js
+++ b/webapp bot bms/backend/models/Client.js
@@ -6,7 +6,6 @@ const clientSchema = new mongoose.Schema({
   enabled: { type: Boolean, default: false },
   ipAddress: String,
   location: String,
-  groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
   connectionStatus: { type: Boolean, default: false },
   lastReport: Date
 });

--- a/webapp bot bms/backend/models/Group.js
+++ b/webapp bot bms/backend/models/Group.js
@@ -2,7 +2,9 @@ import mongoose from '../config/database.js';
 
 const groupSchema = new mongoose.Schema({
   groupName: String,
-  description: String
+  description: String,
+  users: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+  points: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Point' }]
 });
 
 export default mongoose.model('Group', groupSchema);

--- a/webapp bot bms/frontend/src/pages/PuntosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/PuntosPage.jsx
@@ -129,17 +129,30 @@ export default function PuntosPage() {
                 <TableCell>{p.clientId?.clientName || p.clientId}</TableCell>
                 <TableCell>
                   {(() => {
-                    const cidGroup = p.clientId?.groupId;
-                    if (cidGroup && typeof cidGroup === 'object') {
-                      return cidGroup.groupName;
+                    const directGroup = p.groupId;
+                    if (directGroup) {
+                      if (typeof directGroup === 'object') {
+                        return (
+                          directGroup.groupName ||
+                          groups.find((g) => g._id === directGroup._id)?.groupName ||
+                          directGroup._id ||
+                          'Sin grupo'
+                        );
+                      }
+                      const fromList = groups.find((g) => g._id === directGroup);
+                      if (fromList) {
+                        return fromList.groupName;
+                      }
+                      return directGroup;
                     }
-                    return (
-                      groups.find((g) => g._id === cidGroup)?.groupName ||
-                      p.groupId?.groupName ||
-                      cidGroup ||
-                      p.groupId ||
-                      'N/A'
+                    const fromGroups = groups.find((g) =>
+                      Array.isArray(g.points) &&
+                      g.points.some((point) => {
+                        const pointId = typeof point === 'string' ? point : point?._id;
+                        return pointId === p._id;
+                      })
                     );
+                    return fromGroups?.groupName || 'Sin grupo';
                   })()}
                 </TableCell>
                 <TableCell>


### PR DESCRIPTION
## Summary
- add user and point relations to the group schema and synchronize memberships when groups change
- remove the client-to-group field while updating controllers to resolve notifications and point filtering through group relations
- update the web UI so groups manage user/point memberships and client/point views reflect the new associations

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d50a1e96748330b37bb6460b5636dd