### PR TITLE
Permitir editar grupo desde puntos y usar último valor reportado

### DIFF
--- a/webapp bot bms/backend/models/Point.js
+++ b/webapp bot bms/backend/models/Point.js
@@ -6,7 +6,9 @@ const pointSchema = new mongoose.Schema({
   pointType: Number,
   pointId: Number,
   groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
-  clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client' }
+  clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client' },
+  lastPresentValue: mongoose.Schema.Types.Mixed,
+  lastUpdate: Date,
 });
 
 export default mongoose.model('Point', pointSchema);

--- a/webapp bot bms/backend/routes/pointRoutes.js
+++ b/webapp bot bms/backend/routes/pointRoutes.js
@@ -1,9 +1,10 @@
 import express from 'express';
-import { reportState, getPoints } from '../controllers/pointController.js';
+import { reportState, getPoints, updatePointGroup } from '../controllers/pointController.js';
 
 const router = express.Router();
 
 router.post('/points/state', reportState);
 router.get('/points', getPoints);
+router.patch('/points/:id/group', updatePointGroup);
 
 export default router;

--- a/webapp bot bms/frontend/src/services/points.js
+++ b/webapp bot bms/frontend/src/services/points.js
@@ -6,3 +6,6 @@ export const fetchPoints = (clientId, groupId) => {
   if (groupId) params.groupId = groupId;
   return axios.get('/api/points', { params });
 };
+
+export const updatePointGroup = (id, groupId) =>
+  axios.patch(`/api/points/${id}/group`, { groupId });


### PR DESCRIPTION
## Resumen
- guardar en cada punto el último valor recibido y seguir generando registros históricos cada 15 minutos
- exponer un endpoint para actualizar la relación grupo-punto y devolver el último valor recibido en la API de puntos
- permitir editar el grupo asociado desde la tabla de puntos con un diálogo de selección

## Pruebas
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d51291e0e88330bd05539ceb8eca32