### PR TITLE
Add group filter and CSV export to trends page

### DIFF
--- a/webapp bot bms/frontend/src/pages/TendenciasPage.jsx
+++ b/webapp bot bms/frontend/src/pages/TendenciasPage.jsx
@@ -7,14 +7,18 @@ import {
   Select,
   MenuItem,
   TextField,
+  Button,
 } from '@mui/material';
 import { fetchPoints } from '../services/points';
 import { fetchDataLogs } from '../services/datalogs';
+import { fetchGroups } from '../services/groups';
 
 /* global Chart */
 
 export default function TendenciasPage() {
+  const [groups, setGroups] = useState([]);
   const [points, setPoints] = useState([]);
+  const [selectedGroup, setSelectedGroup] = useState('');
   const [selectedPoint, setSelectedPoint] = useState('');
   const [logs, setLogs] = useState([]);
   const [startDate, setStartDate] = useState('');
@@ -22,10 +26,23 @@ export default function TendenciasPage() {
   const chartRef = useRef(null);
 
   useEffect(() => {
-    fetchPoints()
-      .then((res) => setPoints(res.data))
+    fetchGroups()
+      .then((res) => setGroups(res.data))
       .catch((err) => console.error(err));
   }, []);
+
+  useEffect(() => {
+    fetchPoints(undefined, selectedGroup || undefined)
+      .then((res) => setPoints(res.data))
+      .catch((err) => console.error(err));
+  }, [selectedGroup]);
+
+  const handleGroupChange = (e) => {
+    const groupId = e.target.value;
+    setSelectedGroup(groupId);
+    setSelectedPoint('');
+    setLogs([]);
+  };
 
   const handlePointChange = (e) => {
     const id = e.target.value;
@@ -46,6 +63,11 @@ export default function TendenciasPage() {
   const isDateRangeInvalid =
     hasAllSelections && !invalidDateValues && startTime > endTime;
 
+  const selectedPointName = useMemo(() => {
+    const point = points.find((p) => p._id === selectedPoint);
+    return point?.pointName || 'tendencia';
+  }, [points, selectedPoint]);
+
   const filteredLogs = useMemo(() => {
     if (
       !hasAllSelections ||
@@ -62,6 +84,39 @@ export default function TendenciasPage() {
       return timestamp >= startTime && timestamp <= endTime;
     });
   }, [endTime, hasAllSelections, invalidDateValues, isDateRangeInvalid, logs, startTime]);
+
+  const handleExportCsv = () => {
+    if (filteredLogs.length === 0) {
+      return;
+    }
+
+    const headers = ['Fecha', 'Valor'];
+    const rows = filteredLogs.map((log) => [
+      new Date(log.timestamp).toISOString(),
+      log.presentValue,
+    ]);
+
+    const escapeCell = (value) =>
+      `"${String(value).replace(/"/g, '""')}"`;
+
+    const csvContent = [headers, ...rows]
+      .map((row) => row.map(escapeCell).join(','))
+      .join('\n');
+
+    const blob = new Blob([`\ufeff${csvContent}`], {
+      type: 'text/csv;charset=utf-8;',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const sanitize = (value) => String(value || '').replace(/[^a-z0-9-_]+/gi, '-');
+    const fileName = `${sanitize(selectedPointName)}-${sanitize(startDate)}-${sanitize(endDate)}.csv`;
+    link.setAttribute('href', url);
+    link.setAttribute('download', fileName);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
 
   useEffect(() => {
     if (!hasAllSelections || filteredLogs.length === 0) {
@@ -115,22 +170,42 @@ export default function TendenciasPage() {
       <Typography variant="h4" gutterBottom>
         Tendencias
       </Typography>
-      <FormControl sx={{ mb: 3, width: '50%' }}>
-        <InputLabel id="point-select-label">Punto</InputLabel>
-        <Select
-          labelId="point-select-label"
-          value={selectedPoint}
-          label="Punto"
-          onChange={handlePointChange}
-        >
-          {points.map((p) => (
-            <MenuItem key={p._id} value={p._id}>
-              {p.pointName}
+      <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+        <FormControl sx={{ minWidth: 200, flex: 1 }}>
+          <InputLabel id="group-select-label">Grupo</InputLabel>
+          <Select
+            labelId="group-select-label"
+            value={selectedGroup}
+            label="Grupo"
+            onChange={handleGroupChange}
+          >
+            <MenuItem value="">
+              <em>Todos</em>
             </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-      <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+            {groups.map((group) => (
+              <MenuItem key={group._id} value={group._id}>
+                {group.groupName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl sx={{ minWidth: 200, flex: 1 }}>
+          <InputLabel id="point-select-label">Punto</InputLabel>
+          <Select
+            labelId="point-select-label"
+            value={selectedPoint}
+            label="Punto"
+            onChange={handlePointChange}
+          >
+            {points.map((p) => (
+              <MenuItem key={p._id} value={p._id}>
+                {p.pointName}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 2, mb: 3, alignItems: 'center', flexWrap: 'wrap' }}>
         <TextField
           label="Inicio"
           type="datetime-local"
@@ -145,6 +220,13 @@ export default function TendenciasPage() {
           value={endDate}
           onChange={(e) => setEndDate(e.target.value)}
         />
+        <Button
+          variant="contained"
+          onClick={handleExportCsv}
+          disabled={filteredLogs.length === 0}
+        >
+          Exportar CSV
+        </Button>
       </Box>
       {!hasAllSelections && (
         <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## Summary
- fetch groups and allow filtering points by selected grupo before choosing a punto
- reset selections when changing grupo and fetch point list accordingly
- add CSV export button that downloads the visible tendencia data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c61059f0833093e3422dca9ead1d