### PR TITLE
Refactor client offline alerts into configurable alarms

### DIFF
--- a/webapp bot bms/backend/controllers/alarmController.js
+++ b/webapp bot bms/backend/controllers/alarmController.js
@@ -1,8 +1,87 @@
 import Alarm from '../models/Alarm.js';
 
+const MONITOR_TYPES = ['point', 'clientConnection'];
+
+function buildAlarmPayload(input, fallbackMonitorType = 'point') {
+  const monitorType = input.monitorType ?? fallbackMonitorType ?? 'point';
+  if (!MONITOR_TYPES.includes(monitorType)) {
+    throw new Error('Tipo de monitoreo inválido');
+  }
+
+  const alarmName = input.alarmName;
+  const groupId = input.groupId;
+  const conditionType = input.conditionType;
+
+  if (!alarmName) {
+    throw new Error('Nombre de alarma requerido');
+  }
+
+  if (!groupId) {
+    throw new Error('Grupo requerido');
+  }
+
+  if (!conditionType) {
+    throw new Error('Condición requerida');
+  }
+
+  if (!['true', 'false', 'gt', 'lt'].includes(conditionType)) {
+    throw new Error('Condición inválida');
+  }
+
+  if (monitorType === 'clientConnection') {
+    const clientId = input.clientId;
+    if (!clientId) {
+      throw new Error('Cliente requerido para alarmas de conexión');
+    }
+    if (conditionType !== 'gt' && conditionType !== 'lt') {
+      throw new Error('Condición inválida para alarmas de conexión');
+    }
+    const numericThreshold = Number(input.threshold);
+    if (!Number.isFinite(numericThreshold) || numericThreshold < 0) {
+      throw new Error('El umbral debe ser un número válido de segundos');
+    }
+    return {
+      alarmName,
+      groupId,
+      conditionType,
+      monitorType,
+      clientId,
+      pointId: null,
+      threshold: numericThreshold,
+    };
+  }
+
+  const pointId = input.pointId;
+  if (!pointId) {
+    throw new Error('Punto requerido');
+  }
+
+  let threshold = null;
+  if (conditionType === 'gt' || conditionType === 'lt') {
+    const numericThreshold = Number(input.threshold);
+    if (!Number.isFinite(numericThreshold)) {
+      throw new Error('El umbral debe ser un número válido');
+    }
+    threshold = numericThreshold;
+  }
+
+  return {
+    alarmName,
+    groupId,
+    conditionType,
+    monitorType: 'point',
+    pointId,
+    clientId: null,
+    threshold,
+  };
+}
+
 export const getAlarms = async (req, res) => {
   try {
-    const alarms = await Alarm.find().populate('pointId').populate('groupId');
+    const alarms = await Alarm.find()
+      .populate('pointId')
+      .populate('groupId')
+      .populate('clientId');
     res.json(alarms);
   } catch (err) {
     res.status(500).json({ message: 'Error al obtener alarmas' });
@@ -10,8 +89,15 @@ export const getAlarms = async (req, res) => {
 };
 
 export const createAlarm = async (req, res) => {
+  let payload;
   try {
-    const alarm = await Alarm.create(req.body);
+    payload = buildAlarmPayload(req.body);
+  } catch (validationError) {
+    return res.status(400).json({ message: validationError.message });
+  }
+
+  try {
+    const alarm = await Alarm.create(payload);
     res.status(201).json(alarm);
   } catch (err) {
     res.status(500).json({ message: 'Error al crear alarma' });
@@ -20,23 +106,22 @@ export const createAlarm = async (req, res) => {
 
 export const updateAlarm = async (req, res) => {
   try {
-    const updateData = { ...req.body };
-    if (
-      updateData.conditionType &&
-      updateData.conditionType !== 'gt' &&
-      updateData.conditionType !== 'lt'
-    ) {
-      updateData.threshold = null;
+    const existing = await Alarm.findById(req.params.id);
+    if (!existing) {
+      return res.status(404).json({ message: 'Alarma no encontrada' });
     }
 
-    const alarm = await Alarm.findByIdAndUpdate(req.params.id, updateData, {
+    let payload;
+    try {
+      payload = buildAlarmPayload(req.body, existing.monitorType ?? 'point');
+    } catch (validationError) {
+      return res.status(400).json({ message: validationError.message });
+    }
+
+    const alarm = await Alarm.findByIdAndUpdate(req.params.id, payload, {
       new: true,
       runValidators: true,
     });
-
-    if (!alarm) {
-      return res.status(404).json({ message: 'Alarma no encontrada' });
-    }
 
     res.json(alarm);
   } catch (err) {

--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -2,11 +2,8 @@ import Client from '../models/Client.js';
 import crypto from 'crypto';
 import Point from '../models/Point.js';
 import Alarm from '../models/Alarm.js';
-import Group from '../models/Group.js';
-import {
-  sendClientOfflineWhatsApp,
-  sendClientOnlineWhatsApp,
-} from '../services/twilioService.js';
+import User from '../models/User.js';
+import { sendAlarmWhatsApp } from '../services/twilioService.js';
 
 function generateApiKey() {
   return crypto.randomBytes(32).toString('hex');
@@ -14,59 +11,71 @@ function generateApiKey() {
 
 export const getClients = async (req, res) => {
   try {
-    const clients = await Client.find();
+    const [clients, connectionAlarms] = await Promise.all([
+      Client.find(),
+      Alarm.find({ monitorType: 'clientConnection' }),
+    ]);
+
+    const alarmsByClient = new Map();
+    for (const alarm of connectionAlarms) {
+      const clientKey = alarm.clientId?.toString();
+      if (!clientKey) continue;
+      if (!alarmsByClient.has(clientKey)) {
+        alarmsByClient.set(clientKey, []);
+      }
+      alarmsByClient.get(clientKey).push(alarm);
+    }
+
     const now = Date.now();
     for (const client of clients) {
       const connected = Boolean(
         client.lastReport && now - client.lastReport.getTime() <= 90000
       );
+
       if (client.connectionStatus !== connected) {
-        const clientLabel =
-          client.clientName || client._id?.toString() || 'desconocido';
+        client.connectionStatus = connected;
+        await client.save();
+      }
 
-        const notifyUsers = async (sendFn, actionLabel) => {
+      const clientAlarms = alarmsByClient.get(client._id.toString());
+      if (!clientAlarms || clientAlarms.length === 0) {
+        continue;
+      }
+
+      const secondsWithoutReport =
+        client.lastReport instanceof Date
+          ? (now - client.lastReport.getTime()) / 1000
+          : Number.POSITIVE_INFINITY;
+
+      for (const alarm of clientAlarms) {
+        let triggered = false;
+        const threshold = Number(alarm.threshold ?? 0);
+        if (alarm.conditionType === 'gt') {
+          triggered = secondsWithoutReport >= threshold;
+        } else if (alarm.conditionType === 'lt') {
+          triggered = secondsWithoutReport <= threshold;
+        }
+
+        if (triggered && !alarm.active) {
           try {
-            const relatedPoints = await Point.find({ clientId: client._id }).select('_id');
-            if (relatedPoints.length === 0) {
-              return;
-            }
-            const pointIds = relatedPoints.map((p) => p._id);
-            const groups = await Group.find({ points: { $in: pointIds } })
-              .populate({ path: 'users', select: 'phoneNum username' })
-              .lean();
-
-            const notified = new Set();
-            for (const group of groups) {
-              if (!Array.isArray(group.users)) continue;
-              for (const user of group.users) {
-                if (!user?.phoneNum || notified.has(user.phoneNum)) continue;
-                try {
-                  await sendFn(user.phoneNum, user.username, clientLabel);
-                  notified.add(user.phoneNum);
-                } catch (error) {
-                  console.error(
-                    `Error enviando WhatsApp de ${actionLabel}`,
-                    error.message
-                  );
-                }
+            const users = await User.find({ groupId: alarm.groupId });
+            for (const u of users) {
+              if (!u?.phoneNum) continue;
+              try {
+                await sendAlarmWhatsApp(u.phoneNum, u.username, alarm.alarmName);
+              } catch (error) {
+                console.error('Error enviando WhatsApp de alarma', error.message);
               }
             }
           } catch (error) {
-            console.error(
-              `Error al notificar ${actionLabel} del cliente`,
-              error.message
-            );
+            console.error('Error al notificar alarma de conexión', error.message);
           }
-        };
-
-        if (client.connectionStatus === true && !connected) {
-          await notifyUsers(sendClientOfflineWhatsApp, 'desconexión');
-        } else if (client.connectionStatus === false && connected) {
-          await notifyUsers(sendClientOnlineWhatsApp, 'reconexión');
+          alarm.active = true;
+          await alarm.save();
+        } else if (!triggered && alarm.active) {
+          alarm.active = false;
+          await alarm.save();
         }
-
-        client.connectionStatus = connected;
-        await client.save();
       }
     }
     res.json(clients);
@@ -139,6 +148,10 @@ export const updateClientEnabled = async (req, res) => {
       if (pointIds.length > 0) {
         await Alarm.updateMany({ pointId: { $in: pointIds } }, { active: false });
       }
+      await Alarm.updateMany(
+        { clientId: client._id, monitorType: 'clientConnection' },
+        { active: false }
+      );
     }
     await client.save();
     res.json(client);

--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -73,7 +73,10 @@ export const reportState = async (req, res) => {
         await DataLog.create({ pointId: point._id, presentValue, timestamp: now });
       }
 
-      const alarms = await Alarm.find({ pointId: point._id });
+      const alarms = await Alarm.find({
+        pointId: point._id,
+        $or: [{ monitorType: { $exists: false } }, { monitorType: 'point' }],
+      });
       for (const alarm of alarms) {
         let triggered = false;
         if (alarm.conditionType === 'true') triggered = Boolean(presentValue) === true;

--- a/webapp bot bms/backend/models/Alarm.js
+++ b/webapp bot bms/backend/models/Alarm.js
@@ -2,10 +2,28 @@ import mongoose from '../config/database.js';
 
 const alarmSchema = new mongoose.Schema({
   alarmName: { type: String, required: true },
-  pointId: { type: mongoose.Schema.Types.ObjectId, ref: 'Point', required: true },
+  monitorType: {
+    type: String,
+    enum: ['point', 'clientConnection'],
+    default: 'point',
+  },
+  pointId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Point',
+    required() {
+      return (this.monitorType ?? 'point') === 'point';
+    },
+  },
+  clientId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Client',
+    required() {
+      return (this.monitorType ?? 'point') === 'clientConnection';
+    },
+  },
   groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group', required: true },
   conditionType: { type: String, enum: ['true', 'false', 'gt', 'lt'], required: true },
-  threshold: mongoose.Schema.Types.Mixed,
+  threshold: { type: Number, default: null },
   active: { type: Boolean, default: false },
 });
 

--- a/webapp bot bms/frontend/src/components/TopBar.jsx
+++ b/webapp bot bms/frontend/src/components/TopBar.jsx
@@ -36,12 +36,26 @@ export default function TopBar() {
 
   const activeAlarmsCount = activeAlarms.length;
 
+  const getAlarmTargetLabel = (alarm) => {
+    if ((alarm.monitorType ?? 'point') === 'clientConnection') {
+      let clientName = '';
+      if (alarm.clientId && typeof alarm.clientId === 'object') {
+        clientName = alarm.clientId.clientName || alarm.clientId.name || '';
+      } else if (typeof alarm.clientId === 'string') {
+        clientName = alarm.clientId;
+      }
+      return `${clientName || 'Cliente'} — Client connection status`;
+    }
+    return alarm.pointId?.pointName || alarm.pointId || 'Sin asignar';
+  };
+
   const formatCondition = (alarm) => {
+    const suffix = (alarm.monitorType ?? 'point') === 'clientConnection' ? ' s' : '';
     switch (alarm.conditionType) {
       case 'gt':
-        return `>= ${alarm.threshold ?? '-'}`;
+        return `>= ${alarm.threshold ?? '-'}${suffix}`;
       case 'lt':
-        return `<= ${alarm.threshold ?? '-'}`;
+        return `<= ${alarm.threshold ?? '-'}${suffix}`;
       case 'true':
         return '== true';
       case 'false':
@@ -204,7 +218,7 @@ export default function TopBar() {
                       secondary={(
                         <>
                           <Typography variant="body2" color="text.secondary">
-                            Punto: {alarm.pointId?.pointName || alarm.pointId || 'Sin asignar'}
+                            Punto: {getAlarmTargetLabel(alarm)}
                           </Typography>
                           <Typography variant="body2" color="text.secondary">
                             Grupo: {alarm.groupId?.groupName || alarm.groupId || 'Sin asignar'}

--- a/webapp bot bms/frontend/src/pages/AlarmsPage.jsx
+++ b/webapp bot bms/frontend/src/pages/AlarmsPage.jsx
@@ -30,6 +30,16 @@ import { fetchPoints } from '../services/points';
 import { fetchGroups } from '../services/groups';
 import { fetchClients } from '../services/clients';
 
+const createEmptyAlarmState = () => ({
+  alarmName: '',
+  monitorType: 'point',
+  pointId: '',
+  clientId: '',
+  groupId: '',
+  conditionType: 'true',
+  threshold: '',
+});
+
 export default function AlarmsPage() {
   const [alarms, setAlarms] = useState([]);
   const [points, setPoints] = useState([]);
@@ -38,7 +48,7 @@ export default function AlarmsPage() {
   const [clients, setClients] = useState([]);
   const [filterGroup, setFilterGroup] = useState('');
   const [clientFilter, setClientFilter] = useState('');
-  const [newAlarm, setNewAlarm] = useState({ alarmName: '', pointId: '', groupId: '', conditionType: 'true', threshold: '' });
+  const [newAlarm, setNewAlarm] = useState(() => createEmptyAlarmState());
   const [error, setError] = useState('');
   const [deleteId, setDeleteId] = useState(null);
   const [editAlarm, setEditAlarm] = useState(null);
@@ -59,16 +69,173 @@ export default function AlarmsPage() {
     });
   }, [clientFilter]);
 
+  useEffect(() => {
+    setNewAlarm((prev) => ({ ...prev, clientId: clientFilter }));
+  }, [clientFilter]);
+
   const load = async () => {
     const { data } = await fetchAlarms();
     setAlarms(data);
   };
 
+  const buildPayloadFromState = (state) => {
+    const monitorType = state.monitorType ?? 'point';
+    const payload = {
+      alarmName: state.alarmName?.trim() ?? '',
+      groupId: state.groupId,
+      conditionType: state.conditionType,
+      monitorType,
+    };
+
+    if (!payload.alarmName) {
+      throw new Error('Ingrese un nombre para la alarma');
+    }
+    if (!payload.groupId) {
+      throw new Error('Seleccione un grupo');
+    }
+    if (!payload.conditionType) {
+      throw new Error('Seleccione una condición');
+    }
+
+    if (monitorType === 'clientConnection') {
+      const clientId = state.clientId || '';
+      if (!clientId) {
+        throw new Error('Seleccione un cliente para la alarma');
+      }
+      const thresholdValue = Number(state.threshold);
+      if (!Number.isFinite(thresholdValue) || thresholdValue < 0) {
+        throw new Error('Ingrese los segundos sin reporte');
+      }
+      return {
+        ...payload,
+        clientId,
+        threshold: thresholdValue,
+      };
+    }
+
+    const pointId = state.pointId || '';
+    if (!pointId) {
+      throw new Error('Seleccione un punto');
+    }
+
+    const numericCondition = payload.conditionType === 'gt' || payload.conditionType === 'lt';
+    const result = {
+      ...payload,
+      pointId,
+    };
+
+    if (numericCondition) {
+      const thresholdValue = Number(state.threshold);
+      if (!Number.isFinite(thresholdValue)) {
+        throw new Error('Ingrese un valor válido para el umbral');
+      }
+      result.threshold = thresholdValue;
+    } else {
+      result.threshold = null;
+    }
+
+    return result;
+  };
+
+  const handleNewAlarmTargetChange = (value) => {
+    setNewAlarm((prev) => {
+      if (value === 'clientConnection') {
+        return {
+          ...prev,
+          monitorType: 'clientConnection',
+          pointId: '',
+          clientId: clientFilter || prev.clientId || '',
+          conditionType: prev.conditionType === 'gt' || prev.conditionType === 'lt' ? prev.conditionType : 'gt',
+          threshold: prev.threshold || '60',
+        };
+      }
+      return {
+        ...prev,
+        monitorType: 'point',
+        pointId: value,
+        clientId: '',
+        conditionType: prev.conditionType || 'true',
+        threshold:
+          prev.conditionType === 'gt' || prev.conditionType === 'lt'
+            ? prev.threshold
+            : '',
+      };
+    });
+  };
+
+  const handleEditTargetChange = (value) => {
+    setEditAlarm((prev) => {
+      if (!prev) return prev;
+      if (value === 'clientConnection') {
+        return {
+          ...prev,
+          monitorType: 'clientConnection',
+          pointId: '',
+          clientId: prev.clientId || '',
+          conditionType: prev.conditionType === 'gt' || prev.conditionType === 'lt' ? prev.conditionType : 'gt',
+          threshold: prev.threshold || '60',
+        };
+      }
+      return {
+        ...prev,
+        monitorType: 'point',
+        pointId: value,
+        clientId: '',
+        conditionType: prev.conditionType || 'true',
+        threshold:
+          prev.conditionType === 'gt' || prev.conditionType === 'lt'
+            ? prev.threshold
+            : '',
+      };
+    });
+  };
+
+  const renderAlarmTarget = (alarm) => {
+    const monitorType = alarm.monitorType ?? 'point';
+    if (monitorType === 'clientConnection') {
+      let clientName = '';
+      if (alarm.clientId && typeof alarm.clientId === 'object') {
+        clientName = alarm.clientId.clientName || alarm.clientId.name || '';
+      } else if (typeof alarm.clientId === 'string') {
+        const client = clients.find((c) => c._id === alarm.clientId);
+        clientName = client?.clientName || '';
+      }
+      return `${clientName || 'Cliente'} — Client connection status`;
+    }
+    return alarm.pointId?.pointName || alarm.pointId || 'Sin asignar';
+  };
+
+  const renderConditionLabel = (alarm) => {
+    const monitorType = alarm.monitorType ?? 'point';
+    const suffix = monitorType === 'clientConnection' ? ' s' : '';
+    if (alarm.conditionType === 'gt') {
+      return `>= ${alarm.threshold ?? '-'}${suffix}`;
+    }
+    if (alarm.conditionType === 'lt') {
+      return `<= ${alarm.threshold ?? '-'}${suffix}`;
+    }
+    if (alarm.conditionType === 'true') {
+      return '== true';
+    }
+    if (alarm.conditionType === 'false') {
+      return '== false';
+    }
+    return 'Condición desconocida';
+  };
+
   const handleAdd = async () => {
+    let payload;
     try {
-      await createAlarm(newAlarm);
+      payload = buildPayloadFromState(newAlarm);
+    } catch (validationError) {
+      setError(validationError.message);
+      return;
+    }
+
+    try {
+      await createAlarm(payload);
       await load();
-      setNewAlarm({ alarmName: '', pointId: '', groupId: '', conditionType: 'true', threshold: '' });
+      setNewAlarm(() => ({ ...createEmptyAlarmState(), clientId: clientFilter }));
       setError('');
     } catch {
       setError('Error al crear alarma');
@@ -88,16 +255,28 @@ export default function AlarmsPage() {
 
   const handleEditOpen = (alarm) => {
     setEditError('');
+    const monitorType = alarm.monitorType || 'point';
+    const isConnection = monitorType === 'clientConnection';
     setEditAlarm({
       _id: alarm._id,
       alarmName: alarm.alarmName || '',
-      pointId: alarm.pointId?._id || alarm.pointId || '',
+      monitorType,
+      pointId: isConnection ? '' : alarm.pointId?._id || alarm.pointId || '',
+      clientId: isConnection
+        ? alarm.clientId?._id || alarm.clientId || ''
+        : '',
       groupId: alarm.groupId?._id || alarm.groupId || '',
-      conditionType: alarm.conditionType || 'true',
+      conditionType: isConnection
+        ? (alarm.conditionType === 'gt' || alarm.conditionType === 'lt'
+            ? alarm.conditionType
+            : 'gt')
+        : alarm.conditionType || 'true',
       threshold:
-        alarm.conditionType === 'gt' || alarm.conditionType === 'lt'
+        isConnection
           ? alarm.threshold ?? ''
-          : '',
+          : (alarm.conditionType === 'gt' || alarm.conditionType === 'lt'
+              ? alarm.threshold ?? ''
+              : ''),
     });
   };
 
@@ -123,17 +302,16 @@ export default function AlarmsPage() {
 
   const handleUpdate = async () => {
     if (!editAlarm) return;
+    let payload;
     try {
-      await updateAlarm(editAlarm._id, {
-        alarmName: editAlarm.alarmName,
-        pointId: editAlarm.pointId,
-        groupId: editAlarm.groupId,
-        conditionType: editAlarm.conditionType,
-        threshold:
-          editAlarm.conditionType === 'gt' || editAlarm.conditionType === 'lt'
-            ? editAlarm.threshold
-            : null,
-      });
+      payload = buildPayloadFromState(editAlarm);
+    } catch (validationError) {
+      setEditError(validationError.message);
+      return;
+    }
+
+    try {
+      await updateAlarm(editAlarm._id, payload);
       await load();
       handleEditClose();
     } catch {
@@ -177,13 +355,8 @@ export default function AlarmsPage() {
               .map(a => (
               <TableRow key={a._id}>
                 <TableCell>{a.alarmName}</TableCell>
-                <TableCell>{a.pointId?.pointName || a.pointId}</TableCell>
-                <TableCell>
-                  {a.conditionType === 'gt' && `> ${a.threshold}`}
-                  {a.conditionType === 'lt' && `< ${a.threshold}`}
-                  {a.conditionType === 'true' && '== true'}
-                  {a.conditionType === 'false' && '== false'}
-                </TableCell>
+                <TableCell>{renderAlarmTarget(a)}</TableCell>
+                <TableCell>{renderConditionLabel(a)}</TableCell>
                 <TableCell>{a.groupId?.groupName || a.groupId}</TableCell>
                 <TableCell>
                   <IconButton
@@ -229,13 +402,16 @@ export default function AlarmsPage() {
             <InputLabel id="point-label">Punto</InputLabel>
             <Select
               labelId="point-label"
-              value={newAlarm.pointId}
+              value={newAlarm.monitorType === 'clientConnection' ? 'clientConnection' : newAlarm.pointId}
               label="Punto"
-              onChange={e=>setNewAlarm(n=>({ ...n, pointId:e.target.value }))}
+              onChange={e=>handleNewAlarmTargetChange(e.target.value)}
             >
               {points.map(p => (
                 <MenuItem key={p._id} value={p._id}>{p.pointName}</MenuItem>
               ))}
+              {clientFilter && (
+                <MenuItem value="clientConnection">Client connection status</MenuItem>
+              )}
             </Select>
           </FormControl>
           <FormControl sx={{ minWidth:120 }}>
@@ -246,16 +422,26 @@ export default function AlarmsPage() {
               label="Condición"
               onChange={e=>setNewAlarm(n=>({ ...n, conditionType:e.target.value }))}
             >
-              <MenuItem value="true">== true</MenuItem>
-              <MenuItem value="false">== false</MenuItem>
-              <MenuItem value="gt">&gt;=</MenuItem>
-              <MenuItem value="lt">&lt;=</MenuItem>
+              {newAlarm.monitorType === 'clientConnection' ? (
+                <>
+                  <MenuItem value="gt">&gt;=</MenuItem>
+                  <MenuItem value="lt">&lt;=</MenuItem>
+                </>
+              ) : (
+                <>
+                  <MenuItem value="true">== true</MenuItem>
+                  <MenuItem value="false">== false</MenuItem>
+                  <MenuItem value="gt">&gt;=</MenuItem>
+                  <MenuItem value="lt">&lt;=</MenuItem>
+                </>
+              )}
             </Select>
           </FormControl>
           {(newAlarm.conditionType === 'gt' || newAlarm.conditionType === 'lt') && (
             <TextField
-              label="Valor"
+              label={newAlarm.monitorType === 'clientConnection' ? 'Segundos sin reporte' : 'Valor'}
               type="number"
+              inputProps={newAlarm.monitorType === 'clientConnection' ? { min: 0 } : undefined}
               value={newAlarm.threshold}
               onChange={e=>setNewAlarm(n=>({ ...n, threshold:e.target.value }))}
             />
@@ -295,14 +481,30 @@ export default function AlarmsPage() {
             <Select
               labelId="edit-point-label"
               label="Punto"
-              value={editAlarm?.pointId || ''}
-              onChange={(e) => handleEditChange('pointId', e.target.value)}
+              value={editAlarm?.monitorType === 'clientConnection' ? 'clientConnection' : editAlarm?.pointId || ''}
+              onChange={(e) => handleEditTargetChange(e.target.value)}
             >
               {allPoints.map((p) => (
                 <MenuItem key={p._id} value={p._id}>{p.pointName}</MenuItem>
               ))}
+              <MenuItem value="clientConnection">Client connection status</MenuItem>
             </Select>
           </FormControl>
+          {editAlarm?.monitorType === 'clientConnection' && (
+            <FormControl fullWidth>
+              <InputLabel id="edit-client-label">Cliente</InputLabel>
+              <Select
+                labelId="edit-client-label"
+                label="Cliente"
+                value={editAlarm?.clientId || ''}
+                onChange={(e) => handleEditChange('clientId', e.target.value)}
+              >
+                {clients.map((c) => (
+                  <MenuItem key={c._id} value={c._id}>{c.clientName}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <FormControl fullWidth>
             <InputLabel id="edit-group-label">Grupo</InputLabel>
             <Select
@@ -324,16 +526,26 @@ export default function AlarmsPage() {
               value={editAlarm?.conditionType || 'true'}
               onChange={(e) => handleEditChange('conditionType', e.target.value)}
             >
-              <MenuItem value="true">== true</MenuItem>
-              <MenuItem value="false">== false</MenuItem>
-              <MenuItem value="gt">&gt;=</MenuItem>
-              <MenuItem value="lt">&lt;=</MenuItem>
+              {editAlarm?.monitorType === 'clientConnection' ? (
+                <>
+                  <MenuItem value="gt">&gt;=</MenuItem>
+                  <MenuItem value="lt">&lt;=</MenuItem>
+                </>
+              ) : (
+                <>
+                  <MenuItem value="true">== true</MenuItem>
+                  <MenuItem value="false">== false</MenuItem>
+                  <MenuItem value="gt">&gt;=</MenuItem>
+                  <MenuItem value="lt">&lt;=</MenuItem>
+                </>
+              )}
             </Select>
           </FormControl>
           {(editAlarm?.conditionType === 'gt' || editAlarm?.conditionType === 'lt') && (
             <TextField
-              label="Valor"
+              label={editAlarm?.monitorType === 'clientConnection' ? 'Segundos sin reporte' : 'Valor'}
               type="number"
+              inputProps={editAlarm?.monitorType === 'clientConnection' ? { min: 0 } : undefined}
               value={editAlarm?.threshold ?? ''}
               onChange={(e) => handleEditChange('threshold', e.target.value)}
             />


### PR DESCRIPTION
## Summary
- add a monitor type to alarms so client connection status thresholds can be configured and validated server-side
- evaluate client connection alarms when retrieving clients and deactivate them when a client is disabled
- update the alarms UI to create and edit client connection alarms and show the new target in listings and notifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c4878d888330aeaaf2d2329c2da6