### PR TITLE
Fix WhatsApp offline notifications

### DIFF
--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -99,10 +99,10 @@ export async function sendAlarmWhatsApp(to, username, alarmName) {
 
 export async function sendClientOfflineWhatsApp(to, username, clientName) {
   const offlineMessage = `Cliente "${clientName}" fuera de linea`;
-  await sendTemplatedWhatsApp(to, username, offlineMessage, offlineMessage);
+  await sendTemplatedWhatsApp(to, username, clientName, offlineMessage);
 }
 
 export async function sendClientOnlineWhatsApp(to, username, clientName) {
   const onlineMessage = `Cliente "${clientName}" en linea`;
-  await sendTemplatedWhatsApp(to, username, onlineMessage, onlineMessage);
+  await sendTemplatedWhatsApp(to, username, clientName, onlineMessage);
 }


### PR DESCRIPTION
## Summary
- ensure WhatsApp offline and online alerts send the client name as the template variable while keeping full text as fallback

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5d0355da083309b6c02fe4b957777