### PR TITLE
Allow users to join multiple groups

### DIFF
--- a/webapp bot bms/backend/controllers/pointController.js
+++ b/webapp bot bms/backend/controllers/pointController.js
@@ -93,7 +93,7 @@ export const reportState = async (req, res) => {
             } catch (e) {
               console.error('Error registrando evento', e.message);
             }
-            const users = await User.find({ groupId: alarm.groupId });
+            const users = await User.find({ groups: alarm.groupId });
             for (const u of users) {
               if (u.phoneNum) {
                 try {

--- a/webapp bot bms/backend/dbupdated.js
+++ b/webapp bot bms/backend/dbupdated.js
@@ -31,10 +31,13 @@ async function applyChanges() {
       await Group.findByIdAndUpdate(groupId, { $addToSet: { points: { $each: pointIds } } });
     }
 
-    // Update users without groupId
-    const updated = await User.updateMany({ groupId: { $exists: false } }, { groupId: groupId });
+    // Update users without groups assigned
+    const updated = await User.updateMany(
+      { $or: [{ groups: { $exists: false } }, { groups: { $size: 0 } }] },
+      { $addToSet: { groups: groupId } }
+    );
     console.log('Usuarios actualizados:', updated.modifiedCount);
-    const usersWithGroup = await User.find({ groupId: groupId }).select('_id');
+    const usersWithGroup = await User.find({ groups: groupId }).select('_id');
     if (usersWithGroup.length > 0) {
       await Group.findByIdAndUpdate(groupId, { $addToSet: { users: { $each: usersWithGroup.map((u) => u._id) } } });
     }

--- a/webapp bot bms/backend/models/User.js
+++ b/webapp bot bms/backend/models/User.js
@@ -6,7 +6,36 @@ const userSchema = new mongoose.Schema({
   name: String,
   phoneNum: String,
   userType: String,
-  groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' }
+  groups: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Group' }]
 });
+
+const appendLegacyGroupId = (_doc, ret) => {
+  const existingGroups = Array.isArray(ret.groups) ? ret.groups : [];
+  if (existingGroups.length === 0 && ret.groupId) {
+    try {
+      ret.groups = [new mongoose.Types.ObjectId(ret.groupId)];
+    } catch (err) {
+      ret.groups = [ret.groupId];
+    }
+  } else {
+    ret.groups = existingGroups;
+  }
+  const [firstGroup] = ret.groups;
+  if (firstGroup && typeof firstGroup === 'object' && firstGroup !== null && firstGroup._id) {
+    ret.groupId = firstGroup._id.toString();
+  } else if (firstGroup) {
+    try {
+      ret.groupId = firstGroup.toString();
+    } catch (err) {
+      ret.groupId = firstGroup;
+    }
+  } else {
+    ret.groupId = null;
+  }
+  return ret;
+};
+
+userSchema.set('toJSON', { transform: appendLegacyGroupId });
+userSchema.set('toObject', { transform: appendLegacyGroupId });
 
 export default mongoose.model('User', userSchema);


### PR DESCRIPTION
## Summary
- update the user schema to store an array of group references and expose a legacy `groupId` for compatibility
- adjust user and group controllers to manage many-to-many assignments and keep group membership lists in sync
- update alarm notification queries and the database helper script to work with the new `groups` field

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5db0d50688330a326d0ecae836614