### PR TITLE
feat: support multi group assignment for users

### DIFF
--- a/webapp bot bms/frontend/src/context/AuthContext.jsx
+++ b/webapp bot bms/frontend/src/context/AuthContext.jsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState } from 'react';
 import axios from 'axios';
 
 const AuthContext = createContext();
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children }) {


### PR DESCRIPTION
## Summary
- allow assigning multiple groups to users from the creation form and edit dialog
- show the list of group names for each user in the users table with helper normalization utilities
- silence the fast refresh lint warning in the auth context helper

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ea96a9a88330968c803beda5e15c