### PR TITLE
Truncate long table values on admin pages

### DIFF
--- a/webapp bot bms/frontend/src/pages/ClientPage.jsx
+++ b/webapp bot bms/frontend/src/pages/ClientPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchClients, createClient, deleteClient, updateClientEnabled, updateClient } from '../services/clients';
 import { fetchGroups } from '../services/groups';
+import { truncateText } from '../utils/text';
 import {
   Container, Typography, TextField, Button, Box,
   Paper, Table, TableHead, TableRow, TableCell, TableBody,
@@ -121,15 +122,15 @@ export default function ClientPage() {
           <TableBody>
             {clients.map(c => (
               <TableRow key={c._id}>
-                <TableCell>{c.clientName}</TableCell>
+                <TableCell>{truncateText(c.clientName)}</TableCell>
                 <TableCell>
                   <FiberManualRecord sx={{ color: c.enabled ? 'green' : 'red' }} />
                   <IconButton size="small" onClick={() => setToggleInfo({ id: c._id, enabled: !c.enabled })}>
                     <Autorenew fontSize="small" />
                   </IconButton>
                 </TableCell>
-                <TableCell>{c.ipAddress}</TableCell>
-                <TableCell>{c.location}</TableCell>
+                <TableCell>{truncateText(c.ipAddress)}</TableCell>
+                <TableCell>{truncateText(c.location)}</TableCell>
                 <TableCell>
                   {(() => {
                     const relatedGroups = groups
@@ -145,13 +146,14 @@ export default function ClientPage() {
                         })
                       )
                       .map((g) => g.groupName);
-                    return relatedGroups.length > 0 ? relatedGroups.join(', ') : 'Sin grupo';
+                    const relatedGroupsText = relatedGroups.length > 0 ? relatedGroups.join(', ') : 'Sin grupo';
+                    return truncateText(relatedGroupsText);
                   })()}
                 </TableCell>
                 <TableCell>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <FiberManualRecord sx={{ color: c.connectionStatus ? 'green' : 'red' }} />
-                    {c.lastReport ? new Date(c.lastReport).toLocaleString() : 'Sin conexión'}
+                    <span>{truncateText(c.lastReport ? new Date(c.lastReport).toLocaleString() : 'Sin conexión')}</span>
                   </Box>
                 </TableCell>
                 <TableCell>

--- a/webapp bot bms/frontend/src/pages/GroupPage.jsx
+++ b/webapp bot bms/frontend/src/pages/GroupPage.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { fetchGroups, createGroup, deleteGroup, updateGroup } from '../services/groups';
 import { fetchUsers } from '../services/users';
 import { fetchPoints } from '../services/points';
+import { truncateText } from '../utils/text';
 import {
   Container, Typography, TextField, Button, Box,
   Paper, Table, TableHead, TableRow, TableCell, TableBody,
@@ -162,7 +163,7 @@ export default function GroupPage() {
       }
       return user?.name || user?.username || userNameById.get(user?._id) || user?._id || 'Desconocido';
     });
-    return names.join(', ');
+    return truncateText(names.join(', '));
   };
 
   const renderGroupPoints = (group) => {
@@ -181,7 +182,7 @@ export default function GroupPage() {
       }
       return pointLabelById.get(point?._id) || labelBase || 'Desconocido';
     });
-    return labels.join(', ');
+    return truncateText(labels.join(', '));
   };
 
   return (
@@ -201,8 +202,8 @@ export default function GroupPage() {
           <TableBody>
             {groups.map((g) => (
               <TableRow key={g._id}>
-                <TableCell>{g.groupName}</TableCell>
-                <TableCell>{g.description}</TableCell>
+                <TableCell>{truncateText(g.groupName)}</TableCell>
+                <TableCell>{truncateText(g.description)}</TableCell>
                 <TableCell>{renderGroupUsers(g)}</TableCell>
                 <TableCell>{renderGroupPoints(g)}</TableCell>
                 <TableCell>

--- a/webapp bot bms/frontend/src/pages/PuntosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/PuntosPage.jsx
@@ -26,6 +26,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import { fetchPoints, updatePointGroup } from '../services/points';
 import { fetchClients } from '../services/clients';
 import { fetchGroups } from '../services/groups';
+import { truncateText } from '../utils/text';
 
 export default function PuntosPage() {
   const [points, setPoints] = useState([]);
@@ -162,31 +163,36 @@ export default function PuntosPage() {
           <TableBody>
             {points.map((p) => (
               <TableRow key={p._id}>
-                <TableCell>{p.pointName}</TableCell>
-                <TableCell>{p.ipAddress}</TableCell>
+                <TableCell>{truncateText(p.pointName)}</TableCell>
+                <TableCell>{truncateText(p.ipAddress)}</TableCell>
                 <TableCell>
-                  {p.pointType}
-                  {typeAcronyms[p.pointType] ? ` (${typeAcronyms[p.pointType]})` : ''}
+                  {truncateText(
+                    `${p.pointType}${
+                      typeAcronyms[p.pointType] ? ` (${typeAcronyms[p.pointType]})` : ''
+                    }`
+                  )}
                 </TableCell>
-                <TableCell>{p.pointId}</TableCell>
-                <TableCell>{p.clientId?.clientName || p.clientId}</TableCell>
+                <TableCell>{truncateText(p.pointId)}</TableCell>
+                <TableCell>{truncateText(p.clientId?.clientName || p.clientId)}</TableCell>
                 <TableCell>
                   {(() => {
                     const directGroup = p.groupId;
                     if (directGroup) {
                       if (typeof directGroup === 'object') {
                         return (
-                          directGroup.groupName ||
-                          groups.find((g) => g._id === directGroup._id)?.groupName ||
-                          directGroup._id ||
-                          'Sin grupo'
+                          truncateText(
+                            directGroup.groupName ||
+                              groups.find((g) => g._id === directGroup._id)?.groupName ||
+                              directGroup._id ||
+                              'Sin grupo'
+                          )
                         );
                       }
                       const fromList = groups.find((g) => g._id === directGroup);
                       if (fromList) {
-                        return fromList.groupName;
+                        return truncateText(fromList.groupName);
                       }
-                      return directGroup;
+                      return truncateText(directGroup);
                     }
                     const fromGroups = groups.find((g) =>
                       Array.isArray(g.points) &&
@@ -195,15 +201,17 @@ export default function PuntosPage() {
                         return pointId === p._id;
                       })
                     );
-                    return fromGroups?.groupName || 'Sin grupo';
+                    return truncateText(fromGroups?.groupName || 'Sin grupo');
                   })()}
                 </TableCell>
                 <TableCell>
-                  {p.lastValue
-                    ? `${p.lastValue.presentValue} (${new Date(
-                        p.lastValue.timestamp
-                      ).toLocaleString()})`
-                    : 'N/A'}
+                  {truncateText(
+                    p.lastValue
+                      ? `${p.lastValue.presentValue} (${new Date(
+                          p.lastValue.timestamp
+                        ).toLocaleString()})`
+                      : 'N/A'
+                  )}
                 </TableCell>
                 <TableCell align="center">
                   <Tooltip title="Editar grupo">

--- a/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
+++ b/webapp bot bms/frontend/src/pages/UsuariosPage.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchUsers, createUser, deleteUser, updateUser } from '../services/users';
 import { fetchGroups } from '../services/groups';
+import { truncateText } from '../utils/text';
 import {
   Container, Typography, TextField, Button, Box,
   Paper, Table, TableHead, TableRow, TableCell, TableBody,
@@ -158,12 +159,12 @@ export default function UsuariosPage() {
           <TableBody>
               {users.map(u => (
                 <TableRow key={u._id}>
-                  <TableCell>{u.username}</TableCell>
-                  <TableCell>{u.password}</TableCell>
-                  <TableCell>{u.name}</TableCell>
-                  <TableCell>{u.phoneNum}</TableCell>
-                  <TableCell>{u.userType}</TableCell>
-                  <TableCell>{renderGroupNames(extractGroupIds(u.groups, u.groupId))}</TableCell>
+                  <TableCell>{truncateText(u.username)}</TableCell>
+                  <TableCell>{truncateText(u.password)}</TableCell>
+                  <TableCell>{truncateText(u.name)}</TableCell>
+                  <TableCell>{truncateText(u.phoneNum)}</TableCell>
+                  <TableCell>{truncateText(u.userType)}</TableCell>
+                  <TableCell>{truncateText(renderGroupNames(extractGroupIds(u.groups, u.groupId)))}</TableCell>
                   <TableCell>
                     <IconButton
                       color="primary"

--- a/webapp bot bms/frontend/src/utils/text.js
+++ b/webapp bot bms/frontend/src/utils/text.js
@@ -1,0 +1,12 @@
+export const truncateText = (value, maxLength = 65) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const str = typeof value === 'string' ? value : String(value);
+  if (str.length <= maxLength) {
+    return str;
+  }
+
+  return `${str.slice(0, maxLength)}...`;
+};


### PR DESCRIPTION
## Summary
- add a shared truncateText helper to cap table cell content displayed in tables
- apply the helper across the user, group, client, and points pages so only 65 characters are shown in listings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5efec7a1c8330a7b2b7fac6613293