### PR TITLE
Update Notification Manager browser title

### DIFF
--- a/webapp bot bms/frontend/index.html
+++ b/webapp bot bms/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/icons/isologo-100x100.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Notification Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp bot bms/frontend/src/pages/LoginPage.jsx
+++ b/webapp bot bms/frontend/src/pages/LoginPage.jsx
@@ -32,6 +32,9 @@ export default function LoginPage() {
           <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
             FusionBMS
           </Typography>
+          <Typography variant="subtitle1" component="p" sx={{ color: 'text.secondary' }}>
+            Notification Manager
+          </Typography>
         </Box>
         <Typography variant="h5" gutterBottom>Iniciar sesión</Typography>
         {error && <Alert severity="error" sx={{ width: '100%', mb: 2 }}>{error}</Alert>}


### PR DESCRIPTION
## Summary
- adjust the HTML page title to display "Notification Manager" in the browser tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f266b244833081b72a72326ae2bf