### PR TITLE
Implement JWT authentication and login lockout

### DIFF
--- a/webapp bot bms/backend/models/User.js
+++ b/webapp bot bms/backend/models/User.js
@@ -1,12 +1,14 @@
 import mongoose from '../config/database.js';
 
 const userSchema = new mongoose.Schema({
-  username: String,
-  password: String,
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
   name: String,
   phoneNum: String,
   userType: String,
-  groups: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Group' }]
+  groups: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Group' }],
+  loginAttempts: { type: Number, default: 0 },
+  isLocked: { type: Boolean, default: false }
 });
 
 const appendLegacyGroupId = (_doc, ret) => {

--- a/webapp bot bms/package.json
+++ b/webapp bot bms/package.json
@@ -9,9 +9,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.17.0",
     "mongoose": "^8.15.1"
   }


### PR DESCRIPTION
## Summary
- hash stored user passwords and strip them from API responses
- issue JWT tokens during login and block accounts after five failed attempts
- ensure user creation and updates hash credentials and add required dependencies

## Testing
- npm install *(fails: registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f2b968588330aa7de4a87171c4e8