### PR TITLE
Update app branding and login typography

### DIFF
--- a/webapp bot bms/frontend/index.html
+++ b/webapp bot bms/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/icons/isologo-100x100.png" />
+    <link rel="icon" type="image/png" href="./icons/isologo-100x100.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NotificationManager v 1.0</title>
+    <title>Notification Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp bot bms/frontend/src/pages/LoginPage.jsx
+++ b/webapp bot bms/frontend/src/pages/LoginPage.jsx
@@ -32,7 +32,11 @@ export default function LoginPage() {
           <Typography variant="h4" component="h1" sx={{ fontWeight: 600 }}>
             FusionBMS
           </Typography>
-          <Typography variant="subtitle1" component="p" sx={{ color: 'text.secondary' }}>
+          <Typography
+            variant="h6"
+            component="p"
+            sx={{ color: '#000', fontWeight: 500, fontSize: '1.2rem' }}
+          >
             Notification Manager
           </Typography>
         </Box>


### PR DESCRIPTION
## Summary
- update the browser tab branding to use the Notification Manager name and corrected icon path
- enlarge the "Notification Manager" tagline on the login screen and render it in black for better emphasis

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6172693608330a9f7b33e9fcd3e9b