### PR TITLE
Limit point decimals and localize auto-reply timestamps

### DIFF
--- a/webapp bot bms/backend/controllers/twilioController.js
+++ b/webapp bot bms/backend/controllers/twilioController.js
@@ -147,7 +147,17 @@ const normalizeDate = (value) => {
   if (!value) return '';
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) return String(value);
-  return date.toISOString();
+
+  return new Intl.DateTimeFormat('es-AR', {
+    timeZone: 'America/Argentina/Buenos_Aires',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(date);
 };
 
 const compareValues = (actual, expected, operator) => {


### PR DESCRIPTION
## Summary
- truncate reported point values to at most two decimal places before storing logs, alarms, and events
- format auto-reply lastUpdate timestamps using the Argentina time zone

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db3e943cd08330905960701a5865ea