### PR TITLE
Remove offline WhatsApp notifications when client disconnects

### DIFF
--- a/webapp bot bms/backend/controllers/clientController.js
+++ b/webapp bot bms/backend/controllers/clientController.js
@@ -3,10 +3,7 @@ import crypto from 'crypto';
 import Point from '../models/Point.js';
 import Alarm from '../models/Alarm.js';
 import Group from '../models/Group.js';
-import {
-  sendClientOfflineWhatsApp,
-  sendClientOnlineWhatsApp,
-} from '../services/twilioService.js';
+import { sendClientOnlineWhatsApp } from '../services/twilioService.js';
 
 function generateApiKey() {
   return crypto.randomBytes(32).toString('hex');
@@ -59,9 +56,7 @@ export const getClients = async (req, res) => {
           }
         };
 
-        if (client.connectionStatus === true && !connected) {
-          await notifyUsers(sendClientOfflineWhatsApp, 'desconexión');
-        } else if (client.connectionStatus === false && connected) {
+        if (client.connectionStatus === false && connected) {
           await notifyUsers(sendClientOnlineWhatsApp, 'reconexión');
         }
 

--- a/webapp bot bms/backend/services/twilioService.js
+++ b/webapp bot bms/backend/services/twilioService.js
@@ -97,11 +97,6 @@ export async function sendAlarmWhatsApp(to, username, alarmName) {
   await sendTemplatedWhatsApp(to, username, alarmName, fallbackBody);
 }
 
-export async function sendClientOfflineWhatsApp(to, username, clientName) {
-  const offlineMessage = `Cliente "${clientName}" fuera de linea`;
-  await sendTemplatedWhatsApp(to, username, offlineMessage, offlineMessage);
-}
-
 export async function sendClientOnlineWhatsApp(to, username, clientName) {
   const onlineMessage = `Cliente "${clientName}" en linea`;
   await sendTemplatedWhatsApp(to, username, onlineMessage, onlineMessage);


### PR DESCRIPTION
## Summary
- remove the automatic offline WhatsApp notification when a client goes offline
- delete the unused Twilio service helper for offline client alerts

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db4482f1b0833083b2bf8a006be425